### PR TITLE
[Posted] Report database name as schema instead of catalog to resolve compatibility issues with Tableau

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,12 +448,11 @@ Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract 
 1. Timestream does not support the queries that contain ":" in the column aliases. Tools like Tableau may not work as expected.
 
 ### Caveats
-1. Timestream does not support `getCatalogs`
-2. Timestream does not support `schemaPatterns`, which may affect the behaviour of some tools.
-3. SQuirreL SQL Client does not support Rows and Arrays. Running a `SELECT` query that returns an Array or a Struct will result in `UnknownType<2,003>`/`UnknownType<2,002>`.
-4. SQLWorkbench/J does not support using `Database Explorer` to describe Timestream databases with an `underscore` in the name, e.g. `grafana_db`.
-5. SQLWorkbench/J does not display the array values within a `java.sql.Struct`, instead SQLWorkbench/J displays the array's base type, e.g.`com.tsshaded.amazonaws.services.timestreamquery.model.Row(DOUBLE, 2)` instead of `({1.3},2)`.
-6. Timestream JDBC driver only works with queries with fully qualified table names.
+1. Timestream supports `getSchemas` and does not support `getCatalogs`, so Tableau will show databae as schemas instead of catalogs. 
+2. SQuirreL SQL Client does not support Rows and Arrays. Running a `SELECT` query that returns an Array or a Struct will result in `UnknownType<2,003>`/`UnknownType<2,002>`.
+3. SQLWorkbench/J does not support using `Database Explorer` to describe Timestream databases with an `underscore` in the name, e.g. `grafana_db`.
+4. SQLWorkbench/J does not display the array values within a `java.sql.Struct`, instead SQLWorkbench/J displays the array's base type, e.g.`com.tsshaded.amazonaws.services.timestreamquery.model.Row(DOUBLE, 2)` instead of `({1.3},2)`.
+5. Timestream JDBC driver only works with queries with fully qualified table names.
 
 ## License
 This library is licensed under the Apache 2.0 License.

--- a/README.md
+++ b/README.md
@@ -444,16 +444,16 @@ To use the JAR with no dependencies in a Java application, the following require
 Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract the Javadoc HTML files, use the following command: `jar -xvf amazon-timestream-jdbc-1.0.0-javadoc.jar`
 
 ### Known Issues
-1. Timestream does not support fully qualified table names. Tools like Tableau may not work as expected.
+1. Timestream does not support fully qualified table names.
 1. Timestream does not support the queries that contain ":" in the column aliases. Tools like Tableau may not work as expected.
 
 ### Caveats
-1. Timestream does not support `getSchemas`, which may affect the behaviour of some tools: 
-    1. SQuirreL SQL Client displays tables without database information.
-1. SQuirreL SQL Client does not support Rows and Arrays. Running a `SELECT` query that returns an Array or a Struct will result in `UnknownType<2,003>`/`UnknownType<2,002>`.
-1. SQLWorkbench/J does not support using `Database Explorer` to describe Timestream databases with an `underscore` in the name, e.g. `grafana_db`.
-1. SQLWorkbench/J does not display the array values within a `java.sql.Struct`, instead SQLWorkbench/J displays the array's base type, e.g.`com.tsshaded.amazonaws.services.timestreamquery.model.Row(DOUBLE, 2)` instead of `({1.3},2)`.
-1. Timestream JDBC driver only works with queries with fully qualified table names.
+1. Timestream does not support `getCatalogs`
+2. Timestream does not support `schemaPatterns`, which may affect the behaviour of some tools.
+3. SQuirreL SQL Client does not support Rows and Arrays. Running a `SELECT` query that returns an Array or a Struct will result in `UnknownType<2,003>`/`UnknownType<2,002>`.
+4. SQLWorkbench/J does not support using `Database Explorer` to describe Timestream databases with an `underscore` in the name, e.g. `grafana_db`.
+5. SQLWorkbench/J does not display the array values within a `java.sql.Struct`, instead SQLWorkbench/J displays the array's base type, e.g.`com.tsshaded.amazonaws.services.timestreamquery.model.Row(DOUBLE, 2)` instead of `({1.3},2)`.
+6. Timestream JDBC driver only works with queries with fully qualified table names.
 
 ## License
 This library is licensed under the Apache 2.0 License.

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract 
 1. Timestream does not support the queries that contain ":" in the column aliases. Tools like Tableau may not work as expected.
 
 ### Caveats
-1. Timestream supports `getSchemas` and does not support `getCatalogs`, so Tableau will show databae as schemas instead of catalogs. 
+1. Timestream JDBC driver supports `getSchemas` and does not support `getCatalogs`, so Tableau will show database as schemas instead of catalogs. 
 2. SQuirreL SQL Client does not support Rows and Arrays. Running a `SELECT` query that returns an Array or a Struct will result in `UnknownType<2,003>`/`UnknownType<2,002>`.
 3. SQLWorkbench/J does not support using `Database Explorer` to describe Timestream databases with an `underscore` in the name, e.g. `grafana_db`.
 4. SQLWorkbench/J does not display the array values within a `java.sql.Struct`, instead SQLWorkbench/J displays the array's base type, e.g.`com.tsshaded.amazonaws.services.timestreamquery.model.Row(DOUBLE, 2)` instead of `({1.3},2)`.

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -16,12 +16,12 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <version>1.0.2</version>
+  <version>2.0.0</version>
 
   <parent>
     <groupId>software.amazon.timestream</groupId>
     <artifactId>timestream</artifactId>
-    <version>1.0.2</version>
+    <version>2.0.0</version>
   </parent>
 
   <artifactId>integrationtest</artifactId>

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -69,7 +69,7 @@ class DatabaseMetaDataIntegrationTest {
 
   /**
    * Test getCatalogs returns empty ResultSet.
-   * @throws SQLException
+   * @throws SQLException the exception thrown
    */
   @Test
   @DisplayName("Test getCatalogs(). Empty result set should be returned")
@@ -85,7 +85,7 @@ class DatabaseMetaDataIntegrationTest {
 
   /**
    * Test getSchemas returns the list of all databases.
-   * @throws SQLException
+   * @throws SQLException the exception thrown
    */
   @Test
   @DisplayName("Test retrieving all databases.")
@@ -102,7 +102,8 @@ class DatabaseMetaDataIntegrationTest {
 
   /**
    * Test getSchemas returns database "JDBC_Integration07_Test_DB" when given matching patterns.
-   * @throws SQLException
+   * @param schemaPattern the schema pattern to be tested
+   * @throws SQLException the exception thrown
    */
   @ParameterizedTest
   @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB"})

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -68,7 +68,7 @@ class DatabaseMetaDataIntegrationTest {
   }
 
   @Test
-  @DisplayName("Test getCatalogs.")
+  @DisplayName("Test getCatalogs(). Empty result set should be returned")
   void testCatalogs() throws SQLException {
     final List<String> databasesList = Arrays.asList(Constants.DATABASES_NAMES);
     final List<String> catalogsList = new ArrayList<>();
@@ -78,17 +78,6 @@ class DatabaseMetaDataIntegrationTest {
       }
     }
     Assertions.assertTrue(catalogsList.isEmpty());
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB"})
-  @DisplayName("Test retrieving database name JDBC_Integration07_Test_DB with pattern.")
-  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
-    try (ResultSet schemas = metaData.getSchemas(null, schemaPattern)) {
-      while (schemas.next()) {
-        Assertions.assertEquals(Constants.DATABASE_NAME, schemas.getString("TABLE_SCHEM"));
-      }
-    }
   }
 
   @Test
@@ -102,6 +91,17 @@ class DatabaseMetaDataIntegrationTest {
       }
     }
     Assertions.assertTrue(schemasList.containsAll(databasesList));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB"})
+  @DisplayName("Test retrieving database name JDBC_Integration07_Test_DB with pattern.")
+  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
+    try (ResultSet schemas = metaData.getSchemas(null, schemaPattern)) {
+      while (schemas.next()) {
+        Assertions.assertEquals(Constants.DATABASE_NAME, schemas.getString("TABLE_SCHEM"));
+      }
+    }
   }
 
   @ParameterizedTest

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -67,6 +67,10 @@ class DatabaseMetaDataIntegrationTest {
     connection.close();
   }
 
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   * @throws SQLException
+   */
   @Test
   @DisplayName("Test getCatalogs(). Empty result set should be returned")
   void testCatalogs() throws SQLException {
@@ -79,6 +83,10 @@ class DatabaseMetaDataIntegrationTest {
     Assertions.assertTrue(catalogsList.isEmpty());
   }
 
+  /**
+   * Test getSchemas returns the list of all databases.
+   * @throws SQLException
+   */
   @Test
   @DisplayName("Test retrieving all databases.")
   void testSchemas() throws SQLException {
@@ -92,6 +100,10 @@ class DatabaseMetaDataIntegrationTest {
     Assertions.assertTrue(schemasList.containsAll(databasesList));
   }
 
+  /**
+   * Test getSchemas returns database "JDBC_Integration07_Test_DB" when given matching patterns.
+   * @throws SQLException
+   */
   @ParameterizedTest
   @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB"})
   @DisplayName("Test retrieving database name JDBC_Integration07_Test_DB with pattern.")

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -68,7 +68,7 @@ class DatabaseMetaDataIntegrationTest {
   }
 
   @Test
-  @DisplayName("Test retrieving all databases.")
+  @DisplayName("Test getCatalogs.")
   void testCatalogs() throws SQLException {
     final List<String> databasesList = Arrays.asList(Constants.DATABASES_NAMES);
     final List<String> catalogsList = new ArrayList<>();
@@ -78,6 +78,19 @@ class DatabaseMetaDataIntegrationTest {
       }
     }
     Assertions.assertTrue(catalogsList.isEmpty());
+  }
+
+  @Test
+  @DisplayName("Test retrieving all databases.")
+  void testSchemas() throws SQLException {
+    final List<String> databasesList = Arrays.asList(Constants.DATABASES_NAMES);
+    final List<String> schemasList = new ArrayList<>();
+    try (ResultSet schemas = metaData.getSchemas()) {
+      while (schemas.next()) {
+        schemasList.add(schemas.getString("TABLE_SCHEM"));
+      }
+    }
+    Assertions.assertTrue(schemasList.containsAll(databasesList));
   }
 
   @ParameterizedTest

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -77,7 +77,7 @@ class DatabaseMetaDataIntegrationTest {
         catalogsList.add(catalogs.getString("TABLE_CAT"));
       }
     }
-    Assertions.assertTrue(catalogsList.containsAll(databasesList));
+    Assertions.assertTrue(catalogsList.isEmpty());
   }
 
   @ParameterizedTest

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -70,7 +70,6 @@ class DatabaseMetaDataIntegrationTest {
   @Test
   @DisplayName("Test getCatalogs(). Empty result set should be returned")
   void testCatalogs() throws SQLException {
-    final List<String> databasesList = Arrays.asList(Constants.DATABASES_NAMES);
     final List<String> catalogsList = new ArrayList<>();
     try (ResultSet catalogs = metaData.getCatalogs()) {
       while (catalogs.next()) {

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -80,6 +80,17 @@ class DatabaseMetaDataIntegrationTest {
     Assertions.assertTrue(catalogsList.isEmpty());
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"JDBC_%", "%_Integration%", "%Test_DB"})
+  @DisplayName("Test retrieving database name JDBC_Integration07_Test_DB with pattern.")
+  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
+    try (ResultSet schemas = metaData.getSchemas(null, schemaPattern)) {
+      while (schemas.next()) {
+        Assertions.assertEquals(Constants.DATABASE_NAME, schemas.getString("TABLE_SCHEM"));
+      }
+    }
+  }
+
   @Test
   @DisplayName("Test retrieving all databases.")
   void testSchemas() throws SQLException {

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -309,7 +309,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+          <!--  <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
@@ -321,7 +321,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -309,7 +309,7 @@
                     </execution>
                 </executions>
             </plugin>
-          <!--  <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
@@ -321,7 +321,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>software.amazon.timestream</groupId>
     <artifactId>amazon-timestream-jdbc</artifactId>
-    <version>1.0.2</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
     <name>amazon-timestream-jdbc</name>
     <description>AWS Timestream JDBC driver</description>
@@ -60,8 +60,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Version properties are written out to be picked up by the driver. -->
-        <driver.major.version>0</driver.major.version>
-        <driver.minor.version>1</driver.minor.version>
+        <driver.major.version>2</driver.major.version>
+        <driver.minor.version>0</driver.minor.version>
         <driver.hotfix.version>0</driver.hotfix.version>
         <driver.version>${project.version}</driver.version>
 
@@ -309,7 +309,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+<!--            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
@@ -321,7 +321,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -309,7 +309,7 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <executions>
@@ -321,7 +321,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>-->
+            </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
@@ -168,8 +168,8 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     for (int i = 1; i <= numColumns; ++i) {
       final int columnType = rsMeta.getColumnType(i);
       columns.add(new Row().withData(
-        createDatum(curDatabase),
-        NULL_DATUM,
+        NULL_DATUM, //TABLE_CAT -AL-
+        createDatum(curDatabase), //TABLE_SCHEM -AL-
         createDatum(curTable),
         createDatum(rsMeta.getColumnName(i)),
         createDatum(columnType),

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
@@ -134,7 +134,7 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     }
 
     // Get the columns for the next table.
-    curDatabase = tablesResult.getString(1);
+    curDatabase = tablesResult.getString(2);
     curTable = tablesResult.getString(3);
     result = statement.executeQuery(String.format("DESCRIBE \"%s\".\"%s\"", curDatabase, curTable));
 

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
@@ -168,8 +168,8 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     for (int i = 1; i <= numColumns; ++i) {
       final int columnType = rsMeta.getColumnType(i);
       columns.add(new Row().withData(
-        NULL_DATUM, //TABLE_CAT -AL-
-        createDatum(curDatabase), //TABLE_SCHEM -AL-
+        NULL_DATUM,
+        createDatum(curDatabase),
         createDatum(curTable),
         createDatum(rsMeta.getColumnName(i)),
         createDatum(columnType),

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -937,7 +937,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
 
   @Override
   public boolean supportsSchemasInDataManipulation() {
-    return false;
+    return true;
   }
 
   @Override

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -935,6 +935,10 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
     return false;
   }
 
+  /**
+   * Retrieves whether a schema name can be used in a data manipulation statement.
+   * @return true since functionality is supported
+   */
   @Override
   public boolean supportsSchemasInDataManipulation() {
     return true;

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -173,7 +173,8 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   @Override
   public ResultSet getCatalogs(){
     LOGGER.debug("Catalogs are not supported. Returning an empty result set.");
-    return new TimestreamSchemasResultSet();
+    return new TimestreamDatabasesResultSet();
+   // return new TimestreamSchemasResultSet();
   }
 
   @Override
@@ -469,12 +470,14 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
 
   @Override
   public ResultSet getSchemas() throws SQLException {
-    return new TimestreamDatabasesResultSet(this.connection, null);
+    return new TimestreamSchemasResultSet(this.connection, null);
+   // return new TimestreamDatabasesResultSet(this.connection, null);
   }
 
   @Override
   public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-    return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
+    return new TimestreamSchemasResultSet(this.connection, schemaPattern);
+    // return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
   }
 
   @Override

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -176,10 +176,6 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
     return new TimestreamSchemasResultSet();
   }
 
-/*  public ResultSet getCatalogs() throws SQLException {
-    return new TimestreamDatabasesResultSet(this.connection);
-  }*/
-
   @Override
   public ResultSet getClientInfoProperties() {
     return new TimestreamPropertiesResultSet();
@@ -474,28 +470,13 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   @Override
   public ResultSet getSchemas() throws SQLException {
     return new TimestreamDatabasesResultSet(this.connection, null);
-    //return new TimestreamDatabasesResultSet(this.connection, null);
   }
-  /*
-  public ResultSet getSchemas() {
-    LOGGER.debug("Schemas are not supported. Returning an empty result set.");
-    return new TimestreamSchemasResultSet();
-  }
-  */
 
   @Override
-  //-AL- no filtering is done here.
   public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
     return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
-    //return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
   }
 
-  /**
-   public ResultSet getSchemas(String catalog, String schemaPattern) {
-   LOGGER.debug("Schemas are not supported. Returning an empty result set.");
-   return new TimestreamSchemasResultSet();
-   }
-   * */
   @Override
   public String getSearchStringEscape() {
     return "%";
@@ -541,7 +522,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
     String tableNamePattern,
     String[] types) throws SQLException {
     return new TimestreamTablesResultSet(connection, schemaPattern, tableNamePattern, types);
-  } // -AL- need to update this here.
+  } // -AL- def need to update this function here for JDBC Enhancement.
 
   @Override
   public String getTimeDateFunctions() {

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -525,7 +525,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
     String tableNamePattern,
     String[] types) throws SQLException {
     return new TimestreamTablesResultSet(connection, schemaPattern, tableNamePattern, types);
-  } // -AL- def need to update this function here for JDBC Enhancement.
+  }
 
   @Override
   public String getTimeDateFunctions() {

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -174,7 +174,6 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   public ResultSet getCatalogs(){
     LOGGER.debug("Catalogs are not supported. Returning an empty result set.");
     return new TimestreamDatabasesResultSet();
-   // return new TimestreamSchemasResultSet();
   }
 
   @Override
@@ -471,13 +470,11 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   @Override
   public ResultSet getSchemas() throws SQLException {
     return new TimestreamSchemasResultSet(this.connection, null);
-   // return new TimestreamDatabasesResultSet(this.connection, null);
   }
 
   @Override
   public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
     return new TimestreamSchemasResultSet(this.connection, schemaPattern);
-    // return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
   }
 
   @Override

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -473,7 +473,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
 
   @Override
   public ResultSet getSchemas() throws SQLException {
-    return new TimestreamDatabasesResultSet(this.connection);
+    return new TimestreamDatabasesResultSet(this.connection, null);
     //return new TimestreamDatabasesResultSet(this.connection, null);
   }
   /*
@@ -486,7 +486,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   @Override
   //-AL- no filtering is done here.
   public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-    return new TimestreamDatabasesResultSet(this.connection);
+    return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
     //return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
   }
 

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -540,8 +540,8 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
     String schemaPattern,
     String tableNamePattern,
     String[] types) throws SQLException {
-    return new TimestreamTablesResultSet(connection, catalog, tableNamePattern, types);
-  }
+    return new TimestreamTablesResultSet(connection, schemaPattern, tableNamePattern, types);
+  } // -AL- need to update this here.
 
   @Override
   public String getTimeDateFunctions() {

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -189,11 +189,11 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getColumns(String catalog, String schemaNamePattern, String tableNamePattern,
+  public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern,
     String columnNamePattern) throws SQLException {
     return new TimestreamColumnsResultSet(
       connection,
-      catalog,
+      schemaPattern,
       tableNamePattern,
       convertPattern(columnNamePattern));
   }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -171,9 +171,14 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getCatalogs() throws SQLException {
-    return new TimestreamDatabasesResultSet(this.connection);
+  public ResultSet getCatalogs(){
+    LOGGER.debug("Catalogs are not supported. Returning an empty result set.");
+    return new TimestreamSchemasResultSet();
   }
+
+/*  public ResultSet getCatalogs() throws SQLException {
+    return new TimestreamDatabasesResultSet(this.connection);
+  }*/
 
   @Override
   public ResultSet getClientInfoProperties() {
@@ -467,17 +472,30 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   }
 
   @Override
+  public ResultSet getSchemas() throws SQLException {
+    return new TimestreamDatabasesResultSet(this.connection);
+    //return new TimestreamDatabasesResultSet(this.connection, null);
+  }
+  /*
   public ResultSet getSchemas() {
     LOGGER.debug("Schemas are not supported. Returning an empty result set.");
     return new TimestreamSchemasResultSet();
   }
+  */
 
   @Override
-  public ResultSet getSchemas(String catalog, String schemaPattern) {
-    LOGGER.debug("Schemas are not supported. Returning an empty result set.");
-    return new TimestreamSchemasResultSet();
+  //-AL- no filtering is done here.
+  public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
+    return new TimestreamDatabasesResultSet(this.connection);
+    //return new TimestreamDatabasesResultSet(this.connection, schemaPattern);
   }
 
+  /**
+   public ResultSet getSchemas(String catalog, String schemaPattern) {
+   LOGGER.debug("Schemas are not supported. Returning an empty result set.");
+   return new TimestreamSchemasResultSet();
+   }
+   * */
   @Override
   public String getSearchStringEscape() {
     return "%";

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
@@ -96,11 +96,8 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
     try (Statement statement = connection.createStatement()) {
       LOGGER.debug("Retrieving a list of databases." + (Strings.isNullOrEmpty(schemaPattern) ? "" : " Schema pattern is " + schemaPattern + "."));
       final String query = "SHOW DATABASES" +
-              (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'"); //-AL- passing this patten
-      // somehow makes tests fail?? Reason: "SHOW DATABASES " makes tests fail, but "SHOW DATABASES" doesn't.
+              (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'");
       try (ResultSet rs = statement.executeQuery(query)) {
-   //   try (ResultSet rs = statement.executeQuery("SHOW DATABASES")) { //-AL- if I use this line instead, tests pass.
-        // but,getSchemas(...) is not called in our code???
         while (rs.next()) {
           databases.add(rs.getString(1));
         }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
@@ -49,7 +49,7 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
     super(null, 20);
     this.rsMeta = createColumnMetadata(COLUMNS);
 
-    populateCurrentRows(connection);
+    populateCurrentRows(connection, schemaPattern);
   }
 
   @Override
@@ -87,9 +87,10 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
    * retrieval path.
    *
    * @param connection The parent connection to retrieve databases from.
+   * @param schemaPattern The schemaPattern to filter databases
    * @throws SQLException if there is an error listing the databases.
    */
-  private void populateCurrentRows(TimestreamConnection connection) throws SQLException {
+  private void populateCurrentRows(TimestreamConnection connection, String schemaPattern) throws SQLException {
     final List<String> databases = new ArrayList<>();
     try (Statement statement = connection.createStatement()) {
       LOGGER.debug("Retrieving a list of databases.");

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
@@ -42,9 +42,10 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
    * Constructor.
    *
    * @param connection the parent connection of the result set.
+   * @param schemaPattern the SchemaPattern. null if not provided
    * @throws SQLException if a database access error occurs.
    */
-  TimestreamDatabasesResultSet(TimestreamConnection connection) throws SQLException {
+  TimestreamDatabasesResultSet(TimestreamConnection connection, String schemaPattern) throws SQLException {
     super(null, 20);
     this.rsMeta = createColumnMetadata(COLUMNS);
 

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
@@ -32,20 +32,28 @@ import java.util.List;
 /**
  * ResultSet for returning the list of databases in Timestream.
  */
-public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TimestreamDatabasesResultSet.class);
+public class TimestreamDatabasesResultSet extends TimestreamEmptyBaseResultSet {
+ // public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
+ // private static final Logger LOGGER = LoggerFactory.getLogger(TimestreamDatabasesResultSet.class);
   private static final List<ColumnInfo> COLUMNS = ImmutableList.of(
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_CAT"));
 
-  private boolean isAfterLast = false;
-
   /**
+   * Constructor.
+   */
+  public TimestreamDatabasesResultSet() {
+    super(COLUMNS);
+  }
+
+/*  private boolean isAfterLast = false;
+
+  *//**
    * Constructor.
    *
    * @param connection the parent connection of the result set.
    * @param schemaPattern the SchemaPattern. null if not provided
    * @throws SQLException if a database access error occurs.
-   */
+   *//*
   TimestreamDatabasesResultSet(TimestreamConnection connection, String schemaPattern) throws SQLException {
     super(null, 20);
     this.rsMeta = createColumnMetadata(COLUMNS);
@@ -71,11 +79,11 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
     LOGGER.debug("Closed is called on this TimestreamDatabasesResultSet, do nothing as the result set has already been closed.");
   }
 
-  /**
+  *//**
    * Retrieve the next page of the results.
    *
    * @return {@code true} if there is another page; {@code false} otherwise.
-   */
+   *//*
   @Override
   protected boolean doNextPage() {
     LOGGER.debug("Attempting to retrieve the next page of results. There are no more pages, return false.");
@@ -83,14 +91,14 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
     return false;
   }
 
-  /**
+  *//**
    * Map the list of databases into a Timestream Row type to allow reuse of the common ResultSet
    * retrieval path.
    *
    * @param connection The parent connection to retrieve databases from.
    * @param schemaPattern The schemaPattern to filter databases
    * @throws SQLException if there is an error listing the databases.
-   */
+   *//*
   private void populateCurrentRows(TimestreamConnection connection, String schemaPattern) throws SQLException {
     final List<String> databases = new ArrayList<>();
     try (Statement statement = connection.createStatement()) {
@@ -108,5 +116,6 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
       .map(d -> new Datum().withScalarValue(d))
       .map(d -> new Row().withData(d))
       .iterator();
-  }
+  }*/
+
 }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
@@ -16,25 +16,14 @@
 package software.amazon.timestream.jdbc;
 
 import com.amazonaws.services.timestreamquery.model.ColumnInfo;
-import com.amazonaws.services.timestreamquery.model.Datum;
-import com.amazonaws.services.timestreamquery.model.Row;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * ResultSet for returning the list of databases in Timestream.
  */
 public class TimestreamDatabasesResultSet extends TimestreamEmptyBaseResultSet {
- // public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
- // private static final Logger LOGGER = LoggerFactory.getLogger(TimestreamDatabasesResultSet.class);
   private static final List<ColumnInfo> COLUMNS = ImmutableList.of(
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_CAT"));
 
@@ -44,78 +33,4 @@ public class TimestreamDatabasesResultSet extends TimestreamEmptyBaseResultSet {
   public TimestreamDatabasesResultSet() {
     super(COLUMNS);
   }
-
-/*  private boolean isAfterLast = false;
-
-  *//**
-   * Constructor.
-   *
-   * @param connection the parent connection of the result set.
-   * @param schemaPattern the SchemaPattern. null if not provided
-   * @throws SQLException if a database access error occurs.
-   *//*
-  TimestreamDatabasesResultSet(TimestreamConnection connection, String schemaPattern) throws SQLException {
-    super(null, 20);
-    this.rsMeta = createColumnMetadata(COLUMNS);
-
-    populateCurrentRows(connection, schemaPattern);
-  }
-
-  @Override
-  public boolean isAfterLast() throws SQLException {
-    verifyOpen();
-    return isAfterLast;
-  }
-
-  @Override
-  public boolean isLast() throws SQLException {
-    verifyOpen();
-    LOGGER.debug("Checking whether the last row of this TimestreamDatabasesResultSet has been reached.");
-    return !isAfterLast && !this.rowItr.hasNext();
-  }
-
-  @Override
-  protected void doClose() {
-    LOGGER.debug("Closed is called on this TimestreamDatabasesResultSet, do nothing as the result set has already been closed.");
-  }
-
-  *//**
-   * Retrieve the next page of the results.
-   *
-   * @return {@code true} if there is another page; {@code false} otherwise.
-   *//*
-  @Override
-  protected boolean doNextPage() {
-    LOGGER.debug("Attempting to retrieve the next page of results. There are no more pages, return false.");
-    this.isAfterLast = true;
-    return false;
-  }
-
-  *//**
-   * Map the list of databases into a Timestream Row type to allow reuse of the common ResultSet
-   * retrieval path.
-   *
-   * @param connection The parent connection to retrieve databases from.
-   * @param schemaPattern The schemaPattern to filter databases
-   * @throws SQLException if there is an error listing the databases.
-   *//*
-  private void populateCurrentRows(TimestreamConnection connection, String schemaPattern) throws SQLException {
-    final List<String> databases = new ArrayList<>();
-    try (Statement statement = connection.createStatement()) {
-      LOGGER.debug("Retrieving a list of databases." + (Strings.isNullOrEmpty(schemaPattern) ? "" : " Schema pattern is " + schemaPattern + "."));
-      final String query = "SHOW DATABASES" +
-              (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'");
-      try (ResultSet rs = statement.executeQuery(query)) {
-        while (rs.next()) {
-          databases.add(rs.getString(1));
-        }
-      }
-    }
-    LOGGER.debug("Retrieved {} databases.", databases.size());
-    this.rowItr = databases.stream()
-      .map(d -> new Datum().withScalarValue(d))
-      .map(d -> new Row().withData(d))
-      .iterator();
-  }*/
-
 }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabasesResultSet.java
@@ -18,6 +18,7 @@ package software.amazon.timestream.jdbc;
 import com.amazonaws.services.timestreamquery.model.ColumnInfo;
 import com.amazonaws.services.timestreamquery.model.Datum;
 import com.amazonaws.services.timestreamquery.model.Row;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,8 +94,13 @@ public class TimestreamDatabasesResultSet extends TimestreamBaseResultSet {
   private void populateCurrentRows(TimestreamConnection connection, String schemaPattern) throws SQLException {
     final List<String> databases = new ArrayList<>();
     try (Statement statement = connection.createStatement()) {
-      LOGGER.debug("Retrieving a list of databases.");
-      try (ResultSet rs = statement.executeQuery("SHOW DATABASES")) {
+      LOGGER.debug("Retrieving a list of databases." + (Strings.isNullOrEmpty(schemaPattern) ? "" : " Schema pattern is " + schemaPattern + "."));
+      final String query = "SHOW DATABASES" +
+              (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'"); //-AL- passing this patten
+      // somehow makes tests fail?? Reason: "SHOW DATABASES " makes tests fail, but "SHOW DATABASES" doesn't.
+      try (ResultSet rs = statement.executeQuery(query)) {
+   //   try (ResultSet rs = statement.executeQuery("SHOW DATABASES")) { //-AL- if I use this line instead, tests pass.
+        // but,getSchemas(...) is not called in our code???
         while (rs.next()) {
           databases.add(rs.getString(1));
         }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -99,7 +99,7 @@ public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
       final String query = "SHOW DATABASES" +
               (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'");
       try (ResultSet rs = statement.executeQuery(query)) {
-        while (rs != null && rs.next()) {
+        while (rs.next()) {
           databases.add(new Row().withData(
                   new Datum().withScalarValue(rs.getString(1)),
                   NULL_DATUM

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -32,21 +32,11 @@ import java.util.List;
  * Result set to return an empty list of schemas in Timestream.
  */
 public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
-//  public class TimestreamSchemasResultSet extends TimestreamEmptyBaseResultSet {
   private static final Logger LOGGER = LoggerFactory.getLogger(TimestreamDatabasesResultSet.class);
   private static final Datum NULL_DATUM = new Datum().withNullValue(Boolean.TRUE);
   private static final List<ColumnInfo> COLUMNS = ImmutableList.of(
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_SCHEM"),
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_CATALOG"));
-
-  /**
-   * Constructor.
-   */
-/*
-  public TimestreamSchemasResultSet() {
-    super(COLUMNS);
-  }
-*/
 
   private boolean isAfterLast = false;
 
@@ -120,11 +110,5 @@ public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
     LOGGER.debug("Retrieved {} databases.", databases.size());
 
     this.rowItr = databases.iterator();
-/*    this.rowItr = databases.stream()
-            .map(d -> new Datum().withScalarValue(d))
-            .map(d -> new Row().withData(d))
-            .iterator();*/
   }
-
-
 }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -101,8 +101,8 @@ public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
       try (ResultSet rs = statement.executeQuery(query)) {
         while (rs != null && rs.next()) {
           databases.add(new Row().withData(
-                  new Datum().withScalarValue(rs.getString(1)), //TABLE_SCHEM
-                  NULL_DATUM //TABLE_CATALOG ,
+                  new Datum().withScalarValue(rs.getString(1)),
+                  NULL_DATUM
           ));
         }
       }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -109,7 +109,7 @@ public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
       final String query = "SHOW DATABASES" +
               (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'");
       try (ResultSet rs = statement.executeQuery(query)) {
-        while (rs.next()) {
+        while (rs != null && rs.next()) {
           databases.add(new Row().withData(
                   new Datum().withScalarValue(rs.getString(1)), //TABLE_SCHEM
                   NULL_DATUM //TABLE_CATALOG ,

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -15,14 +15,26 @@
 package software.amazon.timestream.jdbc;
 
 import com.amazonaws.services.timestreamquery.model.ColumnInfo;
+import com.amazonaws.services.timestreamquery.model.Datum;
+import com.amazonaws.services.timestreamquery.model.Row;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Result set to return an empty list of schemas in Timestream.
  */
-public class TimestreamSchemasResultSet extends TimestreamEmptyBaseResultSet {
+public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
+//  public class TimestreamSchemasResultSet extends TimestreamEmptyBaseResultSet {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimestreamDatabasesResultSet.class);
+  private static final Datum NULL_DATUM = new Datum().withNullValue(Boolean.TRUE);
   private static final List<ColumnInfo> COLUMNS = ImmutableList.of(
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_SCHEM"),
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "TABLE_CATALOG"));
@@ -30,7 +42,90 @@ public class TimestreamSchemasResultSet extends TimestreamEmptyBaseResultSet {
   /**
    * Constructor.
    */
+/*
   public TimestreamSchemasResultSet() {
     super(COLUMNS);
   }
+*/
+
+  private boolean isAfterLast = false;
+
+  /**
+   * Constructor.
+   *
+   * @param connection the parent connection of the result set.
+   * @param schemaPattern the SchemaPattern. null if not provided
+   * @throws SQLException if a database access error occurs.
+   */
+  TimestreamSchemasResultSet(TimestreamConnection connection, String schemaPattern) throws SQLException {
+    super(null, 20);
+    this.rsMeta = createColumnMetadata(COLUMNS);
+
+    populateCurrentRows(connection, schemaPattern);
+  }
+
+  @Override
+  public boolean isAfterLast() throws SQLException {
+    verifyOpen();
+    return isAfterLast;
+  }
+
+  @Override
+  public boolean isLast() throws SQLException {
+    verifyOpen();
+    LOGGER.debug("Checking whether the last row of this TimestreamSchemasResultSet has been reached.");
+    return !isAfterLast && !this.rowItr.hasNext();
+  }
+
+  @Override
+  protected void doClose() {
+    LOGGER.debug("Closed is called on this TimestreamSchemasResultSet, do nothing as the result set has already been closed.");
+  }
+
+  /**
+   * Retrieve the next page of the results.
+   *
+   * @return {@code true} if there is another page; {@code false} otherwise.
+   */
+  @Override
+  protected boolean doNextPage() {
+    LOGGER.debug("Attempting to retrieve the next page of results. There are no more pages, return false.");
+    this.isAfterLast = true;
+    return false;
+  }
+
+  /**
+   * Map the list of databases into a Timestream Row type to allow reuse of the common ResultSet
+   * retrieval path.
+   *
+   * @param connection The parent connection to retrieve databases from.
+   * @param schemaPattern The schemaPattern to filter databases
+   * @throws SQLException if there is an error listing the databases.
+   */
+  private void populateCurrentRows(TimestreamConnection connection, String schemaPattern) throws SQLException {
+    final List<Row> databases = new ArrayList<>();
+    try (Statement statement = connection.createStatement()) {
+      LOGGER.debug("Retrieving a list of databases." + (Strings.isNullOrEmpty(schemaPattern) ? "" : " Schema pattern is " + schemaPattern + "."));
+      final String query = "SHOW DATABASES" +
+              (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'");
+      try (ResultSet rs = statement.executeQuery(query)) {
+        while (rs.next()) {
+          databases.add(new Row().withData(
+                  new Datum().withScalarValue(rs.getString(1)), //TABLE_SCHEM
+                  NULL_DATUM //TABLE_CATALOG ,
+          ));
+        }
+      }
+    }
+    //-AL- todo IMPORTANT put NULL for catalog.
+    LOGGER.debug("Retrieved {} databases.", databases.size());
+
+    this.rowItr = databases.iterator();
+/*    this.rowItr = databases.stream()
+            .map(d -> new Datum().withScalarValue(d))
+            .map(d -> new Row().withData(d))
+            .iterator();*/
+  }
+
+
 }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -117,7 +117,6 @@ public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
         }
       }
     }
-    //-AL- todo IMPORTANT put NULL for catalog.
     LOGGER.debug("Retrieved {} databases.", databases.size());
 
     this.rowItr = databases.iterator();

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -58,12 +58,12 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
    * Constructor.
    *
    * @param connection       the parent connection of the result set.
-   * @param databaseNamePattern         the database pattern to search within.
+   * @param schemaPattern    the schema pattern to use to match database names.
    * @param tableNamePattern the regex pattern to use to match table names.
    * @param types            the types that should be returned.
    * @throws SQLException if a database access error occurs.
    */
-  TimestreamTablesResultSet(TimestreamConnection connection, String databaseNamePattern,
+  TimestreamTablesResultSet(TimestreamConnection connection, String schemaPattern,
     String tableNamePattern,
     String[] types) throws SQLException {
     super(null, 20);
@@ -72,7 +72,7 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
     this.namePattern = tableNamePattern;
 
     if ((null == types) || ((1 == types.length) && (Constants.TABLE_TYPE.equals(types[0])))) {
-      this.databaseItr = getDatabases(databaseNamePattern);
+      this.databaseItr = getDatabases(schemaPattern);
       doNextPage();
     } else {
       // There's currently only a single type of table, if the specified type doesn't match there are now rows,
@@ -127,20 +127,21 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
   /**
    * Retrieve the databases in the Timestream instance to retrieve tables for.
    *
-   * @param database the specified database to use, may be null.
+   * @param schemaPattern the schema pattern to use to match database names, maybe null.
    * @return the databases in the Timestream instance to list tables for.
    * @throws SQLException if there is an error reading from Timestream.
    */
-  private Iterator<String> getDatabases(String database) throws SQLException {
-   /* if (null != database) {
-      LOGGER.debug("Specific database: \"{}\" provided for table retrieval.", database);
+  private Iterator<String> getDatabases(String schemaPattern) throws SQLException {
+   /* if (null != schemaPattern) {
+      LOGGER.debug("Specific database: \"{}\" provided for table retrieval.", schemaPattern);
       // A database was specified, so use that.
-      return ImmutableList.of(database).iterator();
+      return ImmutableList.of(schemaPattern).iterator();
     } */
     //-AL- this part is the causaion of Tableau not having filtered databases, I think
+    // -AL- delete this part after all tests pass
 
-    try (ResultSet rs = new TimestreamSchemasResultSet(connection, database)) {
-    //try (ResultSet rs = new TimestreamDatabasesResultSet(connection, database)) {
+    try (ResultSet rs = new TimestreamSchemasResultSet(connection, schemaPattern)) {
+    //try (ResultSet rs = new TimestreamDatabasesResultSet(connection, schemaPattern)) {
       final List<String> databases = new ArrayList<>();
       while (rs.next()) {
         databases.add(rs.getString(1));

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -132,16 +132,7 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
    * @throws SQLException if there is an error reading from Timestream.
    */
   private Iterator<String> getDatabases(String schemaPattern) throws SQLException {
-   /* if (null != schemaPattern) {
-      LOGGER.debug("Specific database: \"{}\" provided for table retrieval.", schemaPattern);
-      // A database was specified, so use that.
-      return ImmutableList.of(schemaPattern).iterator();
-    } */
-    //-AL- this part is the causaion of Tableau not having filtered databases, I think
-    // -AL- delete this part after all tests pass
-
     try (ResultSet rs = new TimestreamSchemasResultSet(connection, schemaPattern)) {
-    //try (ResultSet rs = new TimestreamDatabasesResultSet(connection, schemaPattern)) {
       final List<String> databases = new ArrayList<>();
       while (rs.next()) {
         databases.add(rs.getString(1));
@@ -167,8 +158,8 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
       try (ResultSet rs = statement.executeQuery(query)) {
         while (rs != null & rs.next()) {
           tables.add(new Row().withData(
-            NULL_DATUM, //TABLE_CAT
-            new Datum().withScalarValue(database), //TABLE_SCHME -AL-
+            NULL_DATUM,
+            new Datum().withScalarValue(database),
             new Datum().withScalarValue(rs.getString(1)),
             new Datum().withScalarValue(Constants.TABLE_TYPE),
             NULL_DATUM,

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -132,13 +132,14 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
    * @throws SQLException if there is an error reading from Timestream.
    */
   private Iterator<String> getDatabases(String database) throws SQLException {
-    if (null != database) {
+   /* if (null != database) {
       LOGGER.debug("Specific database: \"{}\" provided for table retrieval.", database);
       // A database was specified, so use that.
       return ImmutableList.of(database).iterator();
-    }
+    } */
+    //-AL- this part is the causaion of Tableau not having filtered databases, I think
 
-    try (ResultSet rs = new TimestreamDatabasesResultSet(connection, null)) {
+    try (ResultSet rs = new TimestreamDatabasesResultSet(connection, database)) {
       final List<String> databases = new ArrayList<>();
       while (rs.next()) {
         databases.add(rs.getString(1));
@@ -164,8 +165,8 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
       try (ResultSet rs = statement.executeQuery(query)) {
         while (rs.next()) {
           tables.add(new Row().withData(
-            new Datum().withScalarValue(database),
-            NULL_DATUM,
+            NULL_DATUM, //TABLE_CAT
+            new Datum().withScalarValue(database), //TABLE_SCHME -AL-
             new Datum().withScalarValue(rs.getString(1)),
             new Datum().withScalarValue(Constants.TABLE_TYPE),
             NULL_DATUM,

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -58,12 +58,12 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
    * Constructor.
    *
    * @param connection       the parent connection of the result set.
-   * @param database         the database to search within.
+   * @param databaseNamePattern         the database pattern to search within.
    * @param tableNamePattern the regex pattern to use to match table names.
    * @param types            the types that should be returned.
    * @throws SQLException if a database access error occurs.
    */
-  TimestreamTablesResultSet(TimestreamConnection connection, String database,
+  TimestreamTablesResultSet(TimestreamConnection connection, String databaseNamePattern,
     String tableNamePattern,
     String[] types) throws SQLException {
     super(null, 20);
@@ -72,7 +72,7 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
     this.namePattern = tableNamePattern;
 
     if ((null == types) || ((1 == types.length) && (Constants.TABLE_TYPE.equals(types[0])))) {
-      this.databaseItr = getDatabases(database);
+      this.databaseItr = getDatabases(databaseNamePattern);
       doNextPage();
     } else {
       // There's currently only a single type of table, if the specified type doesn't match there are now rows,

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -139,7 +139,8 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
     } */
     //-AL- this part is the causaion of Tableau not having filtered databases, I think
 
-    try (ResultSet rs = new TimestreamDatabasesResultSet(connection, database)) {
+    try (ResultSet rs = new TimestreamSchemasResultSet(connection, database)) {
+    //try (ResultSet rs = new TimestreamDatabasesResultSet(connection, database)) {
       final List<String> databases = new ArrayList<>();
       while (rs.next()) {
         databases.add(rs.getString(1));

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -165,7 +165,7 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
         (Strings.isNullOrEmpty(namePattern) ? "" : " LIKE '" + namePattern + "'");
       LOGGER.debug("Retrieving tables using query: \"{}\"", query);
       try (ResultSet rs = statement.executeQuery(query)) {
-        while (rs.next()) {
+        while (rs != null & rs.next()) {
           tables.add(new Row().withData(
             NULL_DATUM, //TABLE_CAT
             new Datum().withScalarValue(database), //TABLE_SCHME -AL-

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -156,7 +156,7 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
         (Strings.isNullOrEmpty(namePattern) ? "" : " LIKE '" + namePattern + "'");
       LOGGER.debug("Retrieving tables using query: \"{}\"", query);
       try (ResultSet rs = statement.executeQuery(query)) {
-        while (rs != null & rs.next()) {
+        while (rs.next()) {
           tables.add(new Row().withData(
             NULL_DATUM,
             new Datum().withScalarValue(database),

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamTablesResultSet.java
@@ -138,7 +138,7 @@ public class TimestreamTablesResultSet extends TimestreamBaseResultSet {
       return ImmutableList.of(database).iterator();
     }
 
-    try (ResultSet rs = new TimestreamDatabasesResultSet(connection)) {
+    try (ResultSet rs = new TimestreamDatabasesResultSet(connection, null)) {
       final List<String> databases = new ArrayList<>();
       while (rs.next()) {
         databases.add(rs.getString(1));

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -19,6 +19,9 @@
     <Method name="populateCurrentRows"/>
   </Match>
   <Match>
+    <!--The exclude is added as currently driver does not support the prepared statement.
+    This is not a new exclude, as it has already been added for populateCurrentRows for
+    TimestreamTablesResultSet in this file.-->
     <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
     <Class name="software.amazon.timestream.jdbc.TimestreamSchemasResultSet"/>
     <Method name="populateCurrentRows" params="software.amazon.timestream.jdbc.TimestreamConnection,java.lang.String" returns="void" />

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -12,7 +12,6 @@
      express or implied. See the License for the specific language governing
      permissions and limitations under the License.
 -->
-<!-- Comment this line out because I want to pass nonconstant string to execute and filter schemas. -->
 <FindBugsFilter>
   <Match>
     <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -12,10 +12,16 @@
      express or implied. See the License for the specific language governing
      permissions and limitations under the License.
 -->
+<!-- Comment this line out because I want to pass nonconstant string to execute and filter schemas. -->
 <FindBugsFilter>
   <Match>
     <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
     <Class name="software.amazon.timestream.jdbc.TimestreamTablesResultSet"/>
     <Method name="populateCurrentRows"/>
+  </Match>
+  <Match>
+    <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDatabasesResultSet"/>
+    <Method name="populateCurrentRows" params="software.amazon.timestream.jdbc.TimestreamConnection,java.lang.String" returns="void" />
   </Match>
 </FindBugsFilter>

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -21,7 +21,7 @@
   </Match>
   <Match>
     <Bug pattern="SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE"/>
-    <Class name="software.amazon.timestream.jdbc.TimestreamDatabasesResultSet"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamSchemasResultSet"/>
     <Method name="populateCurrentRows" params="software.amazon.timestream.jdbc.TimestreamConnection,java.lang.String" returns="void" />
   </Match>
 </FindBugsFilter>

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -52,6 +52,17 @@ class TimestreamDatabaseMetaDataTest {
     dbMetaData = new TimestreamDatabaseMetaData(mockConnection);
   }
 
+  /**
+   * Checks that an empty result set is returned for getCatalogs
+   */
+  @Test
+  void testGetCatalogsWithResult() throws SQLException {
+    initializeWithResult();
+    try (ResultSet resultSet = dbMetaData
+            .getCatalogs()) {
+      Assertions.assertFalse(resultSet.next());
+    }
+  }
   @Test
   void testGetSchemasWithResult() throws SQLException {
     initializeWithResult();

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -66,8 +66,14 @@ class TimestreamDatabaseMetaDataTest {
   @Test
   void testGetSchemasWithResult() throws SQLException {
     initializeWithResult();
+    // test getSchemas()
     try (ResultSet resultSet = dbMetaData
             .getSchemas()) {
+      testGetSchemasResult(resultSet);
+    }
+    // test getSchemas(String, String)
+    try (ResultSet resultSet = dbMetaData
+            .getSchemas(null, null)) {
       testGetSchemasResult(resultSet);
     }
   }

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -86,16 +86,15 @@ class TimestreamDatabaseMetaDataTest {
   }
 
 
-/*  @ParameterizedTest
-  //@ValueSource(strings = {"%test%", "%", "%DB"})
-  @ValueSource(strings = {"%"})
+  @ParameterizedTest
+  @ValueSource(strings = {"%", "testDB", "%testDB%"})
   void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
     initializeWithResult();
     try (ResultSet resultSet = dbMetaData
             .getSchemas(null, schemaPattern)) {
       testGetSchemasResult(resultSet);
     }
-  }*/
+  }
 
   @Test
   void testGetColumnsWithResult() throws SQLException {
@@ -300,6 +299,10 @@ class TimestreamDatabaseMetaDataTest {
     Mockito.when(dbResultSet.next()).thenReturn(true).thenReturn(false);
     Mockito.when(dbResultSet.getString(1)).thenReturn("testDB");
     Mockito.when(mockStatement.executeQuery("SHOW DATABASES")).thenReturn(dbResultSet);
+    Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE '%'")).thenReturn(dbResultSet);
+    Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE '%test%'")).thenReturn(dbResultSet);
+    Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE 'testDB'")).thenReturn(dbResultSet);
+    Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE '%testDB%'")).thenReturn(dbResultSet);
 
     final ResultSet tableResultSet = Mockito.mock(ResultSet.class);
     Mockito.when(tableResultSet.next()).thenReturn(true).thenReturn(false);

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -63,11 +63,11 @@ class TimestreamDatabaseMetaDataTest {
       Assertions.assertFalse(resultSet.next());
     }
   }
+
   @Test
   void testGetSchemasWithResult() throws SQLException {
     initializeWithResult();
 
-    // test getSchemas()
     try (ResultSet resultSet = dbMetaData
             .getSchemas()) {
       testGetSchemasResult(resultSet);
@@ -78,13 +78,11 @@ class TimestreamDatabaseMetaDataTest {
   void testGetSchemasNullParamWithResult() throws SQLException {
     initializeWithResult();
 
-    // test getSchemas(String, String)
     try (ResultSet resultSet = dbMetaData
             .getSchemas(null, null)) {
       testGetSchemasResult(resultSet);
     }
   }
-
 
   @ParameterizedTest
   @ValueSource(strings = {"%", "testDB", "%testDB%"})

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -66,11 +66,18 @@ class TimestreamDatabaseMetaDataTest {
   @Test
   void testGetSchemasWithResult() throws SQLException {
     initializeWithResult();
+
     // test getSchemas()
     try (ResultSet resultSet = dbMetaData
             .getSchemas()) {
       testGetSchemasResult(resultSet);
     }
+  }
+
+  @Test
+  void testGetSchemasNullParamWithResult() throws SQLException {
+    initializeWithResult();
+
     // test getSchemas(String, String)
     try (ResultSet resultSet = dbMetaData
             .getSchemas(null, null)) {
@@ -78,8 +85,8 @@ class TimestreamDatabaseMetaDataTest {
     }
   }
 
-  /*
-  @ParameterizedTest
+
+/*  @ParameterizedTest
   //@ValueSource(strings = {"%test%", "%", "%DB"})
   @ValueSource(strings = {"%"})
   void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -64,6 +64,9 @@ class TimestreamDatabaseMetaDataTest {
     }
   }
 
+  /**
+   * Checks that a result set containing database name "testDB" is returned for getSchemas with no parameters
+   */
   @Test
   void testGetSchemasWithResult() throws SQLException {
     initializeWithResult();
@@ -74,6 +77,9 @@ class TimestreamDatabaseMetaDataTest {
     }
   }
 
+  /**
+   * Checks that a result set containing database name "testDB" is returned for getSchemas with null parameters
+   */
   @Test
   void testGetSchemasNullParamWithResult() throws SQLException {
     initializeWithResult();
@@ -84,6 +90,11 @@ class TimestreamDatabaseMetaDataTest {
     }
   }
 
+  /**
+   * Checks that a result set containing database name "testDB" is returned for getSchemas with schemaPattern
+   * @param schemaPattern Schema pattern to be tested
+   * Input values tested for schemaPattern: {"%", "testDB", "%testDB%"}
+   */
   @ParameterizedTest
   @ValueSource(strings = {"%", "testDB", "%testDB%"})
   void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -53,6 +53,27 @@ class TimestreamDatabaseMetaDataTest {
   }
 
   @Test
+  void testGetSchemasWithResult() throws SQLException {
+    initializeWithResult();
+    try (ResultSet resultSet = dbMetaData
+            .getSchemas()) {
+      testGetSchemasResult(resultSet);
+    }
+  }
+
+  /*
+  @ParameterizedTest
+  //@ValueSource(strings = {"%test%", "%", "%DB"})
+  @ValueSource(strings = {"%"})
+  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
+    initializeWithResult();
+    try (ResultSet resultSet = dbMetaData
+            .getSchemas(null, schemaPattern)) {
+      testGetSchemasResult(resultSet);
+    }
+  }*/
+
+  @Test
   void testGetColumnsWithResult() throws SQLException {
     initializeWithResult();
     try (ResultSet resultSet = dbMetaData
@@ -290,6 +311,27 @@ class TimestreamDatabaseMetaDataTest {
       Assertions.assertEquals(expectation.getColumnName(i), actual.getColumnName(i));
       Assertions.assertEquals(expectation.getColumnType(i), actual.getColumnType(i));
     }
+  }
+
+  /**
+   * Validate resultSet MetaData returned from getSchemas.
+   *
+   * @param resultSet ResultSet need to be validated.
+   * @throws SQLException If an error occurs while retrieving the value.
+   */
+  private void testGetSchemasResult(ResultSet resultSet) throws SQLException {
+    final String[] string1 = {"", "testDB", null};
+    final List<String[]> strings = new ArrayList<>();
+    strings.add(string1);
+
+    int numRows = 0;
+    while (resultSet.next()) {
+      for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
+        Assertions.assertEquals(strings.get(numRows)[i], resultSet.getString(i));
+      }
+      numRows++;
+    }
+    Assertions.assertEquals(1, numRows);
   }
 
   /**

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -299,10 +299,10 @@ class TimestreamDatabaseMetaDataTest {
    * @throws SQLException If an error occurs while retrieving the value.
    */
   private void testGetColumnsResult(ResultSet resultSet) throws SQLException {
-    final String[] string1 = {"", "testDB", null, "testTable", "ColName", "12", "UNKNOWN",
+    final String[] string1 = {"", null, "testDB", "testTable", "ColName", "12", "UNKNOWN",
       "2147483647", null, null, null, "1", null, null, "12", null, "2147483647", "1",
       "YES", null, null, null, null, "NO", "NO"};
-    final String[] string2 = {"", "testDB", null, "testTable", "ColName", "12", "UNKNOWN",
+    final String[] string2 = {"", null, "testDB", "testTable", "ColName", "12", "UNKNOWN",
       "2147483647", null, null, null, "1", null, null, "12", null, "2147483647", "2",
       "YES", null, null, null, null, "NO", "NO"};
     final List<String[]> strings = new ArrayList<>();
@@ -326,7 +326,7 @@ class TimestreamDatabaseMetaDataTest {
    * @throws SQLException If an error occurs while retrieving the value.
    */
   private void testGetTableResult(ResultSet resultSet) throws SQLException {
-    final String[] strings = {"", "testDB", null, "testTable", "TABLE", null, null, null, null,
+    final String[] strings = {"", null, "testDB", "testTable", "TABLE", null, null, null, null,
       null, null};
 
     int numRows = 0;

--- a/performancetest/pom.xml
+++ b/performancetest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>software.amazon.timestream</groupId>
     <artifactId>timestream</artifactId>
-    <version>1.0.2</version>
+    <version>2.0.0</version>
   </parent>
 
   <artifactId>performancetest</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>software.amazon.timestream</groupId>
   <artifactId>timestream</artifactId>
-  <version>1.0.2</version>
+  <version>2.0.0</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -40,7 +40,7 @@
     <mockito.version>2.28.2</mockito.version>
     <slf4j.version>1.7.24</slf4j.version>
     <timestream.version>1.11.872</timestream.version>
-    <timestream.jdbc.version>1.0.0</timestream.jdbc.version>
+    <timestream.jdbc.version>2.0.0</timestream.jdbc.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
<!--- General summary / title -->
report database name as schema instead of catalog

### Description

<!--- Details of what you changed -->

Summary

- report database name as schema instead of catalog in `getTables` and `getColumns`
- implement `getSchemas()` and `getSchemas(string, string)` to return list of database names
- implement `getCatalogs` to return empty list
- tests update 
- bump JDBC version from 1.0.2 to 2.0.0, the next major version
- documentation for setting up the driver with Tableau and other BI tools will be in separate PRs

Note that as a result of this change, applications using the Timestream JDBC driver programmatically may break, so the version of the driver is bumped to the next major version, 2.0.0.

Previously, databases are reported as catalogs. This PR changes the driver to report databases as schemas instead. This change allows Tableau to generate correct SQL queries to the driver.

#### How `getSchemas` and `getCatalogs` function before changes in this PR
```mermaid
graph TD
    A[getSchemas] --> |returns| G
    G[empty result set]
    G --> H[TABLE_SCHEM -> null]
    G --> I[TABLE_CATALOG -> null]

    B[getCatalogs] --> |returns| E[database result set]
    E --> J[TABLE_CAT database name]
```

####  How `getSchemas` and `getCatalogs` function after changes in this PR
```mermaid
graph TD
    A[getSchemas] --> |returns| G
    G[database result set]
    G --> H[TABLE_SCHEM -> database name]
    G --> I[TABLE_CATALOG -> null]

    B[getCatalogs] --> |returns| E[empty result set]
    E --> J[TABLE_CAT -> null]
```

#### How table metadata [is changed](https://github.com/awslabs/amazon-timestream-driver-jdbc/compare/main...Bit-Quill:amazon-timestream-driver-jdbc:alinaliBQ/AT-1169/getSchemas#diff-fa970402ed9dc285046d53eb324502a6fab375cbd21380f1734d0710af1e2a38R160-R162)
Before:
```mermaid
graph TD
    A[getTables] --> |returns| G
    G[tables result set]
    G --> H[TABLE_CAT -> database name]
    G --> I[TABLE_SCHEM -> null]
    G --> K[other return values unchanged]
```

After:
```mermaid
graph TD
    A[getTables] --> |returns| G
    G[tables result set]
    G --> H[TABLE_CAT -> null]
    G --> I[TABLE_SCHEM -> database name]
    G --> K[other return values unchanged]
```

#### How column metadata [is changed](https://github.com/awslabs/amazon-timestream-driver-jdbc/compare/main...Bit-Quill:amazon-timestream-driver-jdbc:alinaliBQ/AT-1169/getSchemas#diff-8566d77e9c35cd0674f5987d89355d740fc7f8b28f04b12122c362a4b1521cb4R170-R172)
Before:
```mermaid
graph TD
    A[getColumns] --> |returns| G
    G[columns result set]
    G --> H[TABLE_CAT -> database name]
    G --> I[TABLE_SCHEM -> null]
    G --> K[other return values unchanged]
```

After:
```mermaid
graph TD
    A[getColumns] --> |returns| G
    G[columns result set]
    G --> H[TABLE_CAT -> null]
    G --> I[TABLE_SCHEM -> database name]
    G --> K[other return values unchanged]
```

#### Test Results

With changes in this PR, tdvt had a 10 times increase of success rate, and Tableau is able to generate correct SQL queries to the driver.


Results from running existing JDBC driver:
```
Test Count: 863 tests
        Passed tests: 10
        Failed tests: 853
        Tests run: 863
        Disabled tests: 0
        Skipped tests: 0

Other information:
        Smoke test time: 37.8 seconds
        Main test time: 1175.82 seconds
        Total time: 1213.62 seconds
```

Results from running JDBC driver on this branch:
```
Test Count: 863 tests
        Passed tests: 100
        Failed tests: 763
        Tests run: 863
        Disabled tests: 0
        Skipped tests: 0

Other information:
        Smoke test time: 18.45 seconds
        Main test time: 432.35 seconds
        Total time: 450.8 seconds
```

Summary of Tableau manual testing results

Test Case | Status / Comments / Cause of Failure | Generated SQL Query (if known)
-- | -- | --
Test Case 1. Validate Schema is displayed properly (all database names are displayed) | PASSED <br /> Database names containing “_”, digit, lower case and upper case can display correctly |  
Test Case 2. Tables are displayed correctly when its database is chosen as Schema | PASSED <br /> Tables with names including digits, dash, period, or underscore are displayed correctly. No table is shown for the empty database, which is correct. |  
Test Case 3. Autogenerated SQL queries are correct | CONDITIONALLY PASSED. Colons (":") are not supported by Timestream  in AS statements. The workaround is to manually correct the generated SQL query to remove the colons (":") in AS statements. | Auto-generated query for retrieving `meta_queries_test_db.DevOpsMulti`: <br />```   SELECT "DevOpsMulti"."az" AS "az", "DevOpsMulti"."cpu_utilization" AS "cpu_utilization","DevOpsMulti"."hostname" AS "hostname","DevOpsMulti"."measure_name" AS "measure_name","DevOpsMulti"."memory_utilization" AS "memory_utilization", "DevOpsMulti"."region" AS "region", "DevOpsMulti"."time" AS "time" FROM "meta_queries_test_db"."DevOpsMulti" "DevOpsMulti" LIMIT 10000 ``` <br /> This query works and runs successfully. <br />Auto-generated query for retrieving `data_queries_test_db.TestComplexTypes`:<br /> ```SELECT "TestComplexTypes"."az" AS "az",     "TestComplexTypes"."instance_id" AS "instance_id",    "TestComplexTypes"."measure_name" AS "measure_name",    "TestComplexTypes"."measure_value::double" AS "measure_value::double",      "TestComplexTypes"."region" AS "region",      "TestComplexTypes"."time" AS "time",    "TestComplexTypes"."vpc" AS "vpc"   FROM "data_queries_test_db"."TestComplexTypes" "TestComplexTypes"  LIMIT 10000```<br /> This query does not work because Timestream server does not support queries with colons(:) in AS statements, it is not due to the driver, and server-side change is needed to make it work. 
Test Case 4. Join 2 tables from the same database | PASSED - Able to join meta_queries_test_db.TestColumnsMetadata1 with meta_queries_test_db.Test.ColumnsMetadata |  
Test Case 5. Join 2 tables with the different names from different databases | PASSED - Able to join tables with names including digits, dash, period, or underscore. | 
Test Case 6 a. Join 2 large tables with the same name from different databases | FAILED. Tableau may generate colons (":") in the AS statement, causing query to fail on the server-side, especially when loading large tables. | The initial query that Tableau generated, which works: <br />``` SELECT "DevOpsMulti"."az" AS "az", "DevOpsMulti1"."az" AS "az (DevOpsMulti1)",   "DevOpsMulti"."cpu_utilization" AS "cpu_utilization", "DevOpsMulti1"."cpu_utilization" AS "cpu_utilization (DevOpsMulti1)",    "DevOpsMulti"."hostname" AS "hostname", "DevOpsMulti1"."hostname" AS "hostname (DevOpsMulti1)", "DevOpsMulti"."measure_name" AS "measure_name", "DevOpsMulti1"."measure_name" AS "measure_name (DevOpsMulti1)",  "DevOpsMulti"."memory_utilization" AS "memory_utilization", "DevOpsMulti1"."memory_utilization" AS "memory_utilization (DevOpsMulti1)", "DevOpsMulti"."region" AS "region", "DevOpsMulti1"."region" AS "region (DevOpsMulti1)", "DevOpsMulti"."time" AS "time", "DevOpsMulti1"."time" AS "time (DevOpsMulti1)" FROM "sampleDB_2"."DevOpsMulti" "DevOpsMulti" INNER JOIN "meta_queries_test_db"."DevOpsMulti" "DevOpsMulti1" ON (("DevOpsMulti"."az" = "DevOpsMulti1"."az") AND ("DevOpsMulti"."hostname" = "DevOpsMulti1"."hostname") AND ("DevOpsMulti"."region" = "DevOpsMulti1"."region") AND ("DevOpsMulti"."measure_name" = "DevOpsMulti1"."measure_name"))  LIMIT 100```<br /> The subsequent query that Tableau generated and sent to the JDBC driver, which does not work:<br />``` SELECT SUM(1) AS "cnt:DevOpsMulti_E34B84972C4C458CB4D4BB86AD06DE0B:ok" FROM "sampleDB_2"."DevOpsMulti" "DevOpsMulti" INNER JOIN "meta_queries_test_db"."DevOpsMulti" "DevOpsMulti1" ON (("DevOpsMulti"."az" = "DevOpsMulti1"."az") AND ("DevOpsMulti"."hostname" = "DevOpsMulti1"."hostname") AND ("DevOpsMulti"."region" = "DevOpsMulti1"."region") AND ("DevOpsMulti"."measure_name" = "DevOpsMulti1"."measure_name")) HAVING (COUNT(1) > 0)```<br /> Tableau tried several times to re-run the query above, but all met with failure due to server not supporting queries including colons (“:“) in the AS statement | 
Test Case 6 b. Join 2 tables with the same name from different databases | PASSED - Able to join `data_queries_test_db.TestScalarTypes` and `meta_queries_test_db.TestScalarTypes`.  This test case worked because the tables contain only 4 rows and Tableau did not generate queries including colons in the AS statement. | ```SELECT "TestScalarTypes"."device_id" AS "device_id", "TestScalarTypes1"."device_id" AS "device_id (TestScalarTypes1)", "TestScalarTypes"."device_type" AS "device_type", "TestScalarTypes1"."device_type" AS "device_type (TestScalarTypes1)", "TestScalarTypes"."flag" AS "flag", "TestScalarTypes1"."flag" AS "flag (TestScalarTypes1)",  "TestScalarTypes"."measure_name" AS "measure_name", "TestScalarTypes1"."measure_name" AS "measure_name (TestScalarTypes1)", "TestScalarTypes"."os_version" AS "os_version", "TestScalarTypes1"."os_version" AS "os_version (TestScalarTypes1)", "TestScalarTypes"."rebuffering_ratio" AS "rebuffering_ratio",  "TestScalarTypes1"."rebuffering_ratio" AS "rebuffering_ratio (TestScalarTypes1)",  "TestScalarTypes"."region" AS "region",  "TestScalarTypes1"."region" AS "region (TestScalarTypes1)",  "TestScalarTypes"."time" AS "time",  "TestScalarTypes1"."time" AS "time (TestScalarTypes1)", "TestScalarTypes"."video_startup_time" AS "video_startup_time", "TestScalarTypes1"."video_startup_time" AS "video_startup_time (TestScalarTypes1)" FROM "meta_queries_test_db"."TestScalarTypes" "TestScalarTypes"  INNER JOIN "data_queries_test_db"."TestScalarTypes" "TestScalarTypes1" ON ("TestScalarTypes"."device_id" = "TestScalarTypes1"."device_id") LIMIT 100```
Test Case 7. Columns names and data types are displayed properly for each table | PASSED - Unicode column name displays correctly. Data types varchar, timestamp, boolean, double, and bigint display correctly. |  
Test Case 8. Filter tables using table name sub-strings | PASSED - Able to filter table names using “.”, “-”, “_”, and text (“Multi“). |  

For details of Tableau manual testing results, please refer to [Tableau Manual Testing Documentation.pdf](https://github.com/Bit-Quill/amazon-timestream-driver-jdbc/files/10211481/Tableau.Manual.Testing.Doc.Dec-12.pdf).


### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
<!-- Any additional reviewers -->