### PR TITLE
[AT-1454] get application name from JDBC driver

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/README.md
+++ b/README.md
@@ -393,6 +393,12 @@ Upon completion, the page will be redirected back to the `Identity providers` pa
     ![](azuread/user_assignment.png)
 1. Select Assign.
 
+###  Application Names
+Timestream JDBC driver could get the upper application name, which is collected by Timesteam. The application name is retrieved almost same for all platforms. The idea is to get all running process info by executing an OS specific command first, then do the match in the result set using the current process ID. The command for Windows is `tasklist`, it is `ps` for Linux and macOS. The application name that is retrieved does not contain any path or credential info. The examples could be referred below.
+
+For Windows if you are using a BI tool like DbVisualizer, the application name is `dbvis.exe`.
+For Linux and macOS if you are using a BI tool like DbVisualizer, the application name is `dbviscmd.sh` or `dbvisgui.sh` depending how it is started.
+
 # Developer Documentation
 
 ## Building the driver

--- a/README.md
+++ b/README.md
@@ -397,7 +397,8 @@ Upon completion, the page will be redirected back to the `Identity providers` pa
 Timestream JDBC driver could get the upper application name, which is collected by Timesteam. The application name is retrieved almost same for all platforms. The idea is to get all running process info by executing an OS specific command first, then do the match in the result set using the current process ID. The command for Windows is `tasklist`, it is `ps` for Linux and macOS. The application name that is retrieved does not contain any path or credential info. The examples could be referred below.
 
 For Windows if you are using a BI tool like DbVisualizer, the application name is `dbvis.exe`.
-For Linux and macOS if you are using a BI tool like DbVisualizer, the application name is `dbviscmd.sh` or `dbvisgui.sh` depending how it is started.
+For Linux if you are using a BI tool like DbVisualizer, the application name is `dbviscmd.sh` or `dbvisgui.sh` if it is started from command line.
+For macOS if you are using a BI tool like DBeaver, the application name is `dbeaver`.
 
 # Developer Documentation
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -70,7 +70,7 @@
 
         <!-- Dependency versions -->
         <awssdk.version>1.11.870</awssdk.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <jsoup.version>1.15.3</jsoup.version>
         <mockito.version>2.28.2</mockito.version>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -127,16 +127,6 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>5.13.0</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>5.13.0</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -127,6 +127,16 @@
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna-platform</artifactId>
+            <version>5.13.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -205,7 +205,8 @@ public class TimestreamDriver implements java.sql.Driver {
                     while ((line = input.readLine()) != null) {
                         line = line.trim();
                         if (line.startsWith(pid)) {
-                            return line.substring(line.indexOf(" ") + 1);
+                            String appPath = line.substring(line.indexOf(" ") + 1);
+                            return appPath.substring(appPath.lastIndexOf("/") + 1);
                         }
                     }
                 }

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -198,7 +198,7 @@ public class TimestreamDriver implements java.sql.Driver {
                         int start = line.indexOf(",");
                         int end = line.indexOf(",", start+1);
                         if (line.substring(start+1, end).contains(pid)){
-                            return line.substring(0, line.indexOf(","));
+                            return line.substring(1, line.indexOf(",") - 1);
                         }
                     }
                 } else {

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDriverTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDriverTest.java
@@ -68,8 +68,7 @@ class TimestreamDriverTest {
 
   @Test
   void testDriverApplicationName() throws SQLException {
-    String expectedResult = "java.exe";
-    Assertions.assertEquals(expectedResult, TimestreamDriver.APPLICATION_NAME);
+    Assertions.assertEquals("java.exe", TimestreamDriver.APPLICATION_NAME);
   }
 
   @ParameterizedTest

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDriverTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDriverTest.java
@@ -68,7 +68,12 @@ class TimestreamDriverTest {
 
   @Test
   void testDriverApplicationName() throws SQLException {
-    Assertions.assertEquals("java.exe", TimestreamDriver.APPLICATION_NAME);
+    final boolean isWindows = System.getProperty("os.name").startsWith("Windows");
+    if (isWindows) {
+        Assertions.assertEquals("java.exe", TimestreamDriver.APPLICATION_NAME);
+    } else {
+        Assertions.assertEquals("java", TimestreamDriver.APPLICATION_NAME);
+    }
   }
 
   @ParameterizedTest

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDriverTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDriverTest.java
@@ -66,6 +66,12 @@ class TimestreamDriverTest {
     Assertions.assertNull(driver.connect(null, null));
   }
 
+  @Test
+  void testDriverApplicationName() throws SQLException {
+    String expectedResult = "java.exe";
+    Assertions.assertEquals(expectedResult, TimestreamDriver.APPLICATION_NAME);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {
       Constants.URL_PREFIX,

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <awssdk.version>1.11.870</awssdk.version>
-    <guava.version>29.0-jre</guava.version>
+    <guava.version>32.0.1-jre</guava.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <jsoup.version>1.15.3</jsoup.version>
     <maven.install.version>3.0.0-M1</maven.install.version>


### PR DESCRIPTION
Description:

- Get application name by using `tasklist /fo csv /nh` to get all process info on Windows. Then matching the process ID to get the application name
- Get application name by using `ps -eo pid,comm` to get all process info on Linux and macOS. Then matching the process ID to get the application name
- Fix dependency vulnerability, Bump guava from 29.0-jre to 32.0.1-jre
- Update codeql-action to v2 for codeql-analysis workflow

Issue:
https://bitquill.atlassian.net/browse/AT-1454