### PR TITLE
AT-1469 remove log configuration and add example for debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,23 @@ To use the JAR with no dependencies in a Java application, the following require
 ### Building and using the Javadoc JAR to extract the Javadoc HTML files (amazon-timestream-jdbc-\<version\>-javadoc.jar)
 Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract the Javadoc HTML files, use the following command: `jar -xvf amazon-timestream-jdbc-1.0.0-javadoc.jar`
 
+### Debug with BI tools
+#### DBeaver
+To enable debug logs, the application should be run with `-Ddbeaver.trace.enabled=true` flag
+
+#### DbVisualizer
+To enable debug mode, the following steps should be done:
+1. Open `Tools -> Debug Window`
+2. Open the `Debug Log` tab
+3. Enable the `Debug DbVisualizer` checkbox
+
+#### Tableau Desktop
+To enable debug mode need to run Tableau Desktop with -DLogLevel=debug flag
+More details on the official [documentation](https://kb.tableau.com/articles/howto/how-to-create-tableau-desktop-debug-logs)
+
+#### Java Application
+Need to change log level to Debug/FINE. See official documentation how to change log level.
+
 ### Known Issues
 1. Timestream does not support fully qualified table names.
 2. Timestream does not support the queries that contain ":" in the column aliases. Tools like Tableau may not work as expected.

--- a/README.md
+++ b/README.md
@@ -456,7 +456,22 @@ Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract 
 
 ### Debug with BI tools
 #### DBeaver
-To enable debug logs, the application should be run with `-Ddbeaver.trace.enabled=true` flag
+1. Search `dbeaver.ini` file - It should be in the home DBeaver directory
+2. Open `dbeaver.ini` file and add line `-Ddbeaver.jdbc.trace=true` to the end of the file 
+3. Restart DBeaver Application
+4. Add driver and Connect to your timestream database.
+5. In DBeaver `Workspace` go to `.metadata` folder
+6. File `jdbc-api-trace.log` contains all JDBC API invocations and all queries with results.
+
+##### The log location Mac example
+/Library/DBeaverData/workspace6/.metadata/dbeaver-debug.log
+
+#### Log example
+2023-07-24 14:53:57.819 - Initializing the client.
+2023-07-24 14:53:57.819 - Creating an AWSStaticCredentialsProvider.
+2023-07-24 14:53:58.375 - Execution context opened (Timestream; Metadata; 1)
+2023-07-24 14:53:58.377 - Initializing the client.
+2023-07-24 14:53:58.377 - Creating an AWSStaticCredentialsProvider.
 
 #### DbVisualizer
 To enable debug mode, the following steps should be done:
@@ -464,12 +479,46 @@ To enable debug mode, the following steps should be done:
 2. Open the `Debug Log` tab
 3. Enable the `Debug DbVisualizer` checkbox
 
+##### The log file location
+`$HOME/.dbvis/sqllogs folder with the .dson extension`
+
 #### Tableau Desktop
 To enable debug mode need to run Tableau Desktop with -DLogLevel=debug flag
 More details on the official [documentation](https://kb.tableau.com/articles/howto/how-to-create-tableau-desktop-debug-logs)
 
 #### Java Application
-Need to change log level to Debug/FINE. See official documentation how to change log level.
+Need to change the log level to `DEBUG` or `FINE`.
+
+#### For Spring based application 
+The log level can be modified by changing application.properties
+
+`logging.level.root=DEBUG`
+`logging.level.software.amazon.timestream.jdbc=FINE`
+
+#### By VM arguments
+1. Create file `logging.properties`
+2. Add line `software.amazon.timestream.jdbc=FINE` to the `logging.properties` file
+3. Run application with arguments `-Djava.util.logging.config.file="logging.properties"`
+
+#### Programmatically in the code
+`public static void setLogLevel(Level level) {
+Logger rootLogger = LogManager.getLogManager().getLogger("");
+   Handler[] handlers = rootLogger.getHandlers();
+   rootLogger.setLevel(level);
+   for (Handler handler : handlers) {
+      if(handler instanceof FileHandler) {
+         handler.setLevel(newLvl);
+      }
+   }`
+}`
+
+#### Logs example
+
+21:23:51.255 [main] INFO software.amazon.timestream.jdbc.TimestreamConnection - Initializing the client.
+21:23:51.256 [main] INFO software.amazon.timestream.jdbc.TimestreamConnection - Creating an AWSStaticCredentialsProvider.
+Jul. 25, 2023 9:23:51 P.M. com.amazonaws.internal.DefaultServiceEndpointBuilder getServiceEndpoint
+INFO: {query.timestream, us-west-2} was not found in region metadata, trying to construct an endpoint using the standard pattern for this region: region
+21:23:53.191 [main] INFO software.amazon.timestream.jdbc.TimestreamStatement - Query ID: SOME_ID
 
 ### Known Issues
 1. Timestream does not support fully qualified table names.

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -17,7 +17,6 @@ package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
@@ -25,12 +24,7 @@ import javax.sql.PooledConnection;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.logging.Level;
+import java.util.*;
 import java.util.logging.Logger;
 
 /**
@@ -41,12 +35,6 @@ public class TimestreamDataSource implements javax.sql.DataSource,
 
   private static final Logger LOGGER = Logger
     .getLogger("TimestreamDataSource");
-
-  static {
-    SLF4JBridgeHandler.removeHandlersForRootLogger();
-    SLF4JBridgeHandler.install();
-    LOGGER.setLevel(Level.FINE);
-  }
 
   @VisibleForTesting
   final ClientConfiguration clientConfiguration = new ClientConfiguration()

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -24,7 +24,11 @@ import javax.sql.PooledConnection;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.logging.Logger;
 
 /**

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -17,18 +17,12 @@ package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
 import com.google.common.base.Strings;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
-import java.nio.charset.StandardCharsets;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -45,14 +39,6 @@ public class TimestreamDriver implements java.sql.Driver {
     static final String APPLICATION_NAME;
 
     static {
-        // We want to use SLF4J as the logging framework, so install the bridge for it.
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-
-        // Enable only >= FINE logs in the JUL Logger since we want to control things via SLF4J. JUL Logger will filter out
-        // messages before it gets to SLF4J if it set to a restrictive level.
-        LOGGER.setLevel(Level.FINE);
-
         APPLICATION_NAME = getApplicationName();
         APP_NAME_SUFFIX = " [" + APPLICATION_NAME + "]";
         LOGGER.finer("Name of the application using the driver: " + APP_NAME_SUFFIX);


### PR DESCRIPTION
## Summary
Our code has a static block that creates a sl4j bridge and set up a log level for the whole application.
That behavior overrides the default application configuration.
With the fix redundant code blocks has been removed and documentation on how to trace using the different application has been added to README.md

## Description
The driver overrides LOG level for the application. (Application print logs that are available only for trace/debug purposes)

## Related Issue
AT-1469

## Tests performed/created
### Unit tests: 
All existing Unit tests passed

### Manual verification:
1. Build the project with the command `mvn clean install`
2. Use the signed jar in `DBeaver`
3. Create a timestream connection
4. Open Logs and verify that timestream driver logs present

1. Build the project with the command `mvn clean install`
2. Use the signed jar in `new java project as a dependency
3. Create a timestream connection
4. Open Logs and verify that timestream driver logs present
5. Change the Log level to debug
6. Verify that additional driver logs are added to log file

## Additional Reviewers
@alexey-temnikov 