### PR TITLE
[AT-1474] Add Support for Region Override with Endpoint Discovery

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Pdeploy
     - name: Upload JARs
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Pdeploy
     - name: Upload JARs to release
       uses: AButler/upload-release-assets@v2.0
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+jdbc/src/main/resources/META-INF/THIRD-PARTY-LICENSES.txt

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/ConnectionTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/ConnectionTest.java
@@ -83,6 +83,46 @@ class ConnectionTest {
   }
 
   @Test
+  void testConnectionWithRegionOverride() throws SQLException {
+    final Properties properties = new Properties();
+    final String urlWithRegion = Constants.URL + "://Region=us-east-1";
+
+    // URL should override property value for region.
+    properties.put("region", "us-west-2");
+
+    try (Connection connection = DriverManager.getConnection(urlWithRegion, properties)) {
+      validateConnection(
+          connection,
+          EXPECTED_DEFAULT_CONNECTION_URL
+      );
+    }
+
+    final TimestreamDataSource dataSource = new TimestreamDataSource();
+    dataSource.setRegion("us-east-1");
+    try (Connection connection = dataSource.getConnection()) {
+      validateConnection(
+          connection,
+          EXPECTED_DEFAULT_CONNECTION_URL
+      );
+    }
+  }
+
+  @Test
+  void testConnectionWithEmptyRegion() {
+    final Properties properties = new Properties();
+    final String urlWithEmptyRegion = Constants.URL + "://Region=";
+
+    Assertions.assertThrows(
+        SQLException.class,
+        () -> DriverManager.getConnection(urlWithEmptyRegion, properties));
+
+    final TimestreamDataSource dataSource = new TimestreamDataSource();
+    dataSource.setEndpoint(urlWithEmptyRegion);
+    dataSource.setRegion("");
+    Assertions.assertThrows(SQLException.class, dataSource::getConnection);
+  }
+
+  @Test
   void testConnectionWithSDKOptions() throws SQLException {
     final Properties properties = new Properties();
     properties.setProperty("RequestTimeout", "1200");

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/Constants.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/Constants.java
@@ -17,6 +17,7 @@ package software.amazon.timestream.integrationtest;
 
 import com.amazonaws.services.timestreamwrite.model.MeasureValueType;
 import com.google.common.collect.ImmutableMap;
+
 import java.util.Map;
 
 /**
@@ -28,16 +29,9 @@ final class Constants {
   static final String TABLE_NAME = "Integration_Test_Table_07";
   static final String NON_EXISTENT_TABLE_NAME = "NotExistTableName";
   static final String[] DATABASES_NAMES = new String[]{
-      "FAST_PATH_TEST_DB",
       "JDBC_Integration07_Test_DB",
-      "TestV1",
-      "devops",
-      "grafanaPerfDB",
-      "grafana_db",
-      "perf07",
-      "performance07",
-      "sampleDB",
-      "testDB"
+      "Integration_Test_DB01",
+      "Integration_Test_DB02"
   };
   static final String[] COLUMN_NAMES = new String[]{
       "hostname",
@@ -56,6 +50,55 @@ final class Constants {
       "measure_value::varchar",
   };
 
+  static final String NO_DB_NO_TB_REGION = "ap-southeast-2";
+  static final String[] NO_DB_DATABASE_NAMES = new String[]{};
+  static final String[] NO_TB_TABLE_NAMES = new String[]{};
+
+  static final String ONE_DB_NO_TB_REGION = "ap-northeast-1";
+  static final String[] ONE_DB_NO_TB_DATABASE_NAME = new String[]{
+      "EmptyDb_1_2.34"
+  };
+  static final String[] ONE_DB_NO_TB_TABLE_NAMES = new String[]{};
+
+  static final String ONE_DB_ONE_TB_REGION = "eu-central-1";
+  static final String[] ONE_DB_ONE_TB_DATABASE_NAME = new String[]{
+      "JDBC_.IntegrationTestDB0088"
+  };
+  static final String[] ONE_DB_ONE_TB_TABLE_NAME = new String[]{
+      "IntegrationTestTable0888",
+  };
+
+  static final String ONE_DB_MUTLI_TB_REGION = "eu-west-1";
+  static final String[] ONE_DB_MUTLI_TB_DATABASES_NAME = new String[]{
+      "JDBC_Inte.gration_Te.st_DB_01"
+  };
+  static final String[] ONE_DB_MUTLI_TB_TABLE_NAMES = new String[]{
+      "Inte.gration_Tes_t_Tab_le_03",
+      "Integ.ration_Te_st_T_able_01",
+      "Integr.ation_Test_Ta_ble_02"
+  };
+
+  static final String[] MULTI_DB_MUTLI_TB_DATABASES_NAMES = new String[]{
+      "JD_BC_Int.egration_Test_DB_001",
+      "JDB.C_Integration-Test_DB_002",
+      "JD-BC_Integration.Test_DB_003"
+  };
+  static final String[] MULTI_DB_MUTLI_TB_TABLE_NAMES1 = new String[]{
+      "Inte-gration_Tes1t_Table_01_01",
+      "Inte-gration2_Te-st_Table_01_02",
+      "Inte-gration_Test_3Ta-ble_01_03"
+  };
+  static final String[] MULTI_DB_MUTLI_TB_TABLE_NAMES2 = new String[]{
+      "Integration-Test_Ta1ble_02_01",
+      "Integration.-Te-st_Table_02_02"
+  };
+  static final String[] MULTI_DB_MUTLI_TB_TABLE_NAMES3 = new String[]{
+      "JD-BC_Integration-Test_Ta1ble_03_01",
+      "JD-BC_Integration.-Te-st_Table_03_02",
+      "JD-BC_Integration--Test2_Table_03_03",
+      "JD-BC_Integration0-Te-st_Ta.ble_03_04"
+  };
+
   static final int TABLE_COLUMN_NUM = 9;
   static final int TABLE_ROW_SIZE = 4;
   static final long HT_TTL_HOURS = 24L;
@@ -72,5 +115,6 @@ final class Constants {
       .put(MeasureValueType.BOOLEAN, BOOLEAN_VALUE)
       .build();
 
-  private Constants() { }
+  private Constants() {
+  }
 }

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataIntegrationTest.java
@@ -46,13 +46,15 @@ class DatabaseMetaDataIntegrationTest {
 
   @BeforeAll
   private static void setUp() {
-    TableManager.createTable();
+    TableManager.createDatabases(Constants.DATABASES_NAMES);
+    TableManager.createTable(Constants.TABLE_NAME, Constants.DATABASE_NAME);
     TableManager.writeRecords();
   }
 
   @AfterAll
   private static void cleanUp() {
-    TableManager.deleteTable();
+    TableManager.deleteTable(Constants.TABLE_NAME, Constants.DATABASE_NAME);
+    TableManager.deleteDatabases(Constants.DATABASES_NAMES);
   }
 
   @BeforeEach
@@ -69,6 +71,7 @@ class DatabaseMetaDataIntegrationTest {
 
   /**
    * Test getCatalogs returns empty ResultSet.
+   *
    * @throws SQLException the exception thrown
    */
   @Test
@@ -85,6 +88,7 @@ class DatabaseMetaDataIntegrationTest {
 
   /**
    * Test getSchemas returns the list of all databases.
+   *
    * @throws SQLException the exception thrown
    */
   @Test
@@ -102,6 +106,7 @@ class DatabaseMetaDataIntegrationTest {
 
   /**
    * Test getSchemas returns database "JDBC_Integration07_Test_DB" when given matching patterns.
+   *
    * @param schemaPattern the schema pattern to be tested
    * @throws SQLException the exception thrown
    */

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataMultiDBMultiTBIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataMultiDBMultiTBIntegrationTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright <2020> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.timestream.integrationtest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.timestream.jdbc.TimestreamDatabaseMetaData;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Integration tests for supported getters in {@link TimestreamDatabaseMetaData}
+ * Test case: Multiples databases with multiple tables
+ */
+class DatabaseMetaDataMultiDBMultiTBIntegrationTest {
+  private DatabaseMetaData metaData;
+  private Connection connection;
+  private List<String[]> tables;
+
+  @BeforeAll
+  private static void setUp() {
+    TableManager.createDatabases(Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES);
+    TableManager.createTables(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES1, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[0]);
+    TableManager.createTables(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES2, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[1]);
+    TableManager.createTables(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES3, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[2]);
+  }
+
+  @AfterAll
+  private static void cleanUp() {
+    TableManager.deleteTables(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES1, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[0]);
+    TableManager.deleteTables(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES2, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[1]);
+    TableManager.deleteTables(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES3, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[2]);
+    TableManager.deleteDatabases(Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES);
+  }
+
+  @BeforeEach
+  private void init() throws SQLException {
+    final Properties p = new Properties();
+    connection = DriverManager.getConnection(Constants.URL, p);
+    metaData = connection.getMetaData();
+    tables = new ArrayList<>();
+    tables.add(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES1);
+    tables.add(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES2);
+    tables.add(Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES3);
+  }
+
+  @AfterEach
+  private void terminate() throws SQLException {
+    connection.close();
+  }
+
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getCatalogs(). Empty result set should be returned")
+  void testCatalogs() throws SQLException {
+    final List<String> catalogsList = new ArrayList<>();
+    try (ResultSet catalogs = metaData.getCatalogs()) {
+      while (catalogs.next()) {
+        catalogsList.add(catalogs.getString("TABLE_CAT"));
+      }
+    }
+    Assertions.assertTrue(catalogsList.isEmpty());
+  }
+
+  /**
+   * Test getSchemas returns the databases.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test retrieving the databases.")
+  void testSchemas() throws SQLException {
+    final List<String> databasesList = Arrays.asList(Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES);
+    final List<String> schemasList = new ArrayList<>();
+    try (ResultSet schemas = metaData.getSchemas()) {
+      while (schemas.next()) {
+        schemasList.add(schemas.getString("TABLE_SCHEM"));
+      }
+    }
+    Assertions.assertTrue(schemasList.containsAll(databasesList));
+  }
+
+  /**
+   * Test getTables returns all tables.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getTables returns all tables")
+  void testTables() throws SQLException {
+    final List<String> allTables = new ArrayList<>();
+
+    // Test all tables from specified database are returned
+    for (int i = 0; i < tables.size(); i++) {
+      final List<String> tableList = Arrays.asList(tables.get(i));
+      allTables.addAll(tableList);
+      final List<String> returnTableList = new ArrayList<>();
+      try (ResultSet tables = metaData.getTables(null, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[i], null, null)) {
+        while (tables.next()) {
+          returnTableList.add(tables.getString("TABLE_NAME"));
+        }
+      }
+      Assertions.assertTrue(returnTableList.containsAll(tableList));
+    }
+
+    // Test all tables from region are returned when no database is specified
+    final List<String> returnAllTableList = new ArrayList<>();
+    try (ResultSet tables = metaData.getTables(null, null, null, null)) {
+      while (tables.next()) {
+        returnAllTableList.add(tables.getString("TABLE_NAME"));
+      }
+    }
+    Assertions.assertTrue(returnAllTableList.containsAll(allTables));
+  }
+
+  /**
+   * Test getSchemas returns databases when given matching patterns.
+   *
+   * @param schemaPattern the schema pattern to be tested
+   * @param index         index of database name in Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @CsvSource(value = {
+    "%ion!_T%' escape '!, 0",
+    "%DB_001, 0",
+    "JDB.C%, 1",
+    "%DB_002, 1",
+    "JD-BC%, 2",
+    "%DB!_003' escape '!, 2",
+  })
+  @DisplayName("Test retrieving database name JD_BC_Int.egration_Test_DB_001, JDB.C_Integration-Test_DB_002, JD-BC_Integration.Test_DB_003 with pattern.")
+  void testGetSchemasWithSchemaPattern(String schemaPattern, int index) throws SQLException {
+    try (ResultSet schemas = metaData.getSchemas(null, schemaPattern)) {
+      Assertions.assertTrue(schemas.next());
+      Assertions.assertEquals(Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[index], schemas.getString("TABLE_SCHEM"));
+    }
+  }
+
+  /**
+   * Test getTables returns tables from JD-BC_Integration.Test_DB_003 when given matching patterns.
+   *
+   * @param tablePattern  the table pattern to be tested
+   * @param schemaPattern the database pattern to be tested
+   * @param dbIndex       index of database. 0 corresponds to Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES1
+   * @param tbIndex       index of table name in specified database
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @CsvSource(value = {
+    "%_Table_01_01, %ion!_T%' escape '!, 0, 0",
+    "%-gration2_Te-st%, JD_BC_Int.%, 0, 1",
+    "_nte-gration_Test_3Ta-ble_0__03, %DB_001, 0, 2",
+    "%!_02!_01' escape '!, %DB_002, 1, 0",
+    "%gration.-Te-st%, %ion-T%, 1, 1",
+    "JD-BC__ntegration-Test_Ta1ble_0__01, %DB!_003' escape '!, 2, 0",
+    "%.-Te-st_T%, %ion.T%, 2, 1",
+    "%3_03, JD-BC%, 2, 2",
+    "%a.ble%' escape '!, %DB!_003' escape '!, 2, 3"
+  })
+  @DisplayName("Test retrieving tables from databases when given matching table and schema patterns.")
+  void testTablesWithTBPatternDBPattern(final String tablePattern, final String schemaPattern, final int dbIndex, final int tbIndex) throws SQLException {
+    try (ResultSet tableResultSet = metaData.getTables(null, schemaPattern, tablePattern, null)) {
+      Assertions.assertTrue(tableResultSet.next());
+      Assertions.assertEquals(tables.get(dbIndex)[tbIndex], tableResultSet.getObject("TABLE_NAME"));
+    }
+  }
+
+  /**
+   * Test getTables returns tables from databases when given matching table patterns.
+   *
+   * @param tablePattern  the table pattern to be tested
+   * @param dbIndex       index of database. 0 corresponds to Constants.MULTI_DB_MUTLI_TB_TABLE_NAMES1
+   * @param tbIndex       index of table name in specified database
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @CsvSource(value = {
+    "_nte-gration_Tes1t_Table_0__01, 0, 0",
+    "%_Table_01_02%, 0, 1",
+    "%-gration_Test%, 0, 2",
+    "%!_02!_01' escape '!, 1, 0",
+    "%_Table_02_02, 1, 1",
+    "%-BC_Integration-Test_Ta1%, 2, 0",
+    "%.-Te-st_T%, 2, 1",
+    "%t2!_T%' escape '!, 2, 2",
+    "%a.ble%' escape '!, 2, 3"
+  })
+  @DisplayName("Test retrieving tables from databases when given matching table patterns.")
+  void testTablesWithTBPattern(final String tablePattern, final int dbIndex, final int tbIndex) throws SQLException {
+    try (ResultSet tableResultSet = metaData.getTables(null, Constants.MULTI_DB_MUTLI_TB_DATABASES_NAMES[dbIndex], tablePattern, null)) {
+      Assertions.assertTrue(tableResultSet.next());
+      Assertions.assertEquals(tables.get(dbIndex)[tbIndex], tableResultSet.getObject("TABLE_NAME"));
+    }
+  }
+}

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataNoDBIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataNoDBIntegrationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright <2020> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.timestream.integrationtest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.timestream.jdbc.TimestreamDatabaseMetaData;
+
+import java.sql.SQLException;
+
+
+/**
+ * Integration tests for supported getters in {@link TimestreamDatabaseMetaData}
+ * Test case: No database
+ */
+class DatabaseMetaDataNoDBIntegrationTest {
+  private final DatabaseMetaDataTest dbTest = new DatabaseMetaDataTest(Constants.NO_DB_NO_TB_REGION,
+    Constants.NO_DB_DATABASE_NAMES,
+    Constants.NO_TB_TABLE_NAMES);
+
+  @BeforeAll
+  private static void setUp() {
+    DatabaseMetaDataTest.setUp(
+      Constants.NO_DB_NO_TB_REGION,
+      Constants.NO_DB_DATABASE_NAMES,
+      Constants.NO_TB_TABLE_NAMES);
+  }
+
+  @AfterAll
+  private static void cleanUp() {
+    DatabaseMetaDataTest.cleanUp(
+      Constants.NO_DB_NO_TB_REGION,
+      Constants.NO_DB_DATABASE_NAMES,
+      Constants.NO_TB_TABLE_NAMES);
+  }
+
+  @BeforeEach
+  private void init() throws SQLException {
+    dbTest.init();
+  }
+
+  @AfterEach
+  private void terminate() throws SQLException {
+    dbTest.terminate();
+  }
+
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getCatalogs(). Empty result set should be returned")
+  void testCatalogs() throws SQLException {
+    dbTest.testCatalogs();
+  }
+
+  /**
+   * Test getSchemas returns empty ResultSet.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getSchemas(), no database should be returned.")
+  void testSchemas() throws SQLException {
+    dbTest.testSchemas();
+  }
+
+  /**
+   * Test getTables returns no table.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getTables(), no table should be returned.")
+  void testTables() throws SQLException {
+    dbTest.testTables();
+  }
+}

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataOneDBMultiTBIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataOneDBMultiTBIntegrationTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright <2020> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.timestream.integrationtest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.timestream.jdbc.TimestreamDatabaseMetaData;
+
+import java.sql.SQLException;
+
+/**
+ * Integration tests for supported getters in {@link TimestreamDatabaseMetaData}
+ * Test case: One database with multiple tables
+ */
+class DatabaseMetaDataOneDBMultiTBIntegrationTest {
+  private final DatabaseMetaDataTest dbTest = new DatabaseMetaDataTest(Constants.ONE_DB_MUTLI_TB_REGION,
+    Constants.ONE_DB_MUTLI_TB_DATABASES_NAME,
+    Constants.ONE_DB_MUTLI_TB_TABLE_NAMES);
+
+  @BeforeAll
+  private static void setUp() {
+    DatabaseMetaDataTest.setUp(
+      Constants.ONE_DB_MUTLI_TB_REGION,
+      Constants.ONE_DB_MUTLI_TB_DATABASES_NAME,
+      Constants.ONE_DB_MUTLI_TB_TABLE_NAMES);
+  }
+
+  @AfterAll
+  private static void cleanUp() {
+    DatabaseMetaDataTest.cleanUp(
+      Constants.ONE_DB_MUTLI_TB_REGION,
+      Constants.ONE_DB_MUTLI_TB_DATABASES_NAME,
+      Constants.ONE_DB_MUTLI_TB_TABLE_NAMES);
+  }
+
+  @BeforeEach
+  private void init() throws SQLException {
+    dbTest.init();
+  }
+
+  @AfterEach
+  private void terminate() throws SQLException {
+    dbTest.terminate();
+  }
+
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getCatalogs(). Empty result set should be returned")
+  void testCatalogs() throws SQLException {
+    dbTest.testCatalogs();
+  }
+
+  /**
+   * Test getSchemas returns the database.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test retrieving the database.")
+  void testSchemas() throws SQLException {
+    dbTest.testSchemas();
+  }
+
+  /**
+   * Test getSchemas returns database "JDBC_Inte.gration_Te.st_DB_01" when given matching patterns.
+   *
+   * @param schemaPattern the schema pattern to be tested
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"%_01", "%_Inte.gration%", "%Te.st_DB%"})
+  @DisplayName("Test retrieving database name JDBC_Inte.gration_Te.st_DB_01 with pattern.")
+  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
+    dbTest.testGetSchemasWithSchemaPattern(schemaPattern);
+  }
+
+  /**
+   * Test getTables returns all tables from database "JDBC_Inte.gration_Te.st_DB_01".
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getTables returns all tables from database \"JDBC_Inte.gration_Te.st_DB_01\"")
+  void testTables() throws SQLException {
+    dbTest.testTables();
+  }
+
+  /**
+   * Test getTables returns tables from JDBC_Inte.gration_Te.st_DB_01 when given matching patterns.
+   *
+   * @param tablePattern  the table pattern to be tested
+   * @param schemaPattern the database pattern to be tested
+   * @param index         index of table name in Constants.ONE_DB_MUTLI_TB_TABLE_NAMES
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @CsvSource(value = {
+    "%tion_Tes_t%, %_01, 0",
+    "_nte.grat_%, %_Inte.gration%, 0",
+    "%_Tes_t_Tab_le_%, %Te.st_DB%, 0",
+    "%g.ration_Te_st%, %_01, 1",
+    "%_nteg.rat_%, %_Inte.gration%, 1",
+    "%_Te_st_T_able_0_, %Te.st_DB%, 1",
+    "%tion_Test%, %_01, 2",
+    "_ntegr.at_%, %_Inte.gration%, 2",
+    "%_Test_Ta_ble_02, %Te.st_DB%, 2"
+  })
+  @DisplayName("Test retrieving Inte.gration_Tes_t_Tab_le_03, Integ.ration_Te_st_T_able_01, Integr.ation_Test_Ta_ble_02 from JDBC_Inte.gration_Te.st_DB_01.")
+  void testTablesWithPatternFromDBWithPattern(final String tablePattern, final String schemaPattern, final int index) throws SQLException {
+    dbTest.testTablesWithPatternFromDBWithPattern(tablePattern, schemaPattern, index);
+  }
+
+  /**
+   * Test getTables returns tables from JDBC_Inte.gration_Te.st_DB_01 when given matching patterns.
+   *
+   * @param tablePattern the table pattern to be tested
+   * @param index        index of table name in Constants.ONE_DB_MUTLI_TB_TABLE_NAMES
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @CsvSource(value = {
+    "%tion_Tes_t%, 0",
+    "_nte.grat_%, 0",
+    "%_Tes_t_Tab_le_%, 0",
+    "%g.ration_Te_st%, 1",
+    "%_nteg.rat_%, 1",
+    "%_Te_st_T_able_0_, 1",
+    "%tion_Test%, 2",
+    "_ntegr.at_%, 2",
+    "%_Test_Ta_ble_02, 2"
+  })
+  @DisplayName("Test retrieving Inte.gration_Tes_t_Tab_le_03, Integ.ration_Te_st_T_able_01, Integr.ation_Test_Ta_ble_02 from JDBC_Inte.gration_Te.st_DB_01.")
+  void testTablesWithPattern(final String tablePattern, final int index) throws SQLException {
+    dbTest.testTablesWithPattern(tablePattern, index);
+  }
+}

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataOneDBNoTBIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataOneDBNoTBIntegrationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright <2020> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.timestream.integrationtest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.timestream.jdbc.TimestreamDatabaseMetaData;
+
+import java.sql.SQLException;
+
+/**
+ * Integration tests for supported getters in {@link TimestreamDatabaseMetaData}
+ * Test case: One database with no tables
+ */
+class DatabaseMetaDataOneDBNoTBIntegrationTest {
+  private final DatabaseMetaDataTest dbTest = new DatabaseMetaDataTest(Constants.ONE_DB_NO_TB_REGION,
+    Constants.ONE_DB_NO_TB_DATABASE_NAME,
+    Constants.ONE_DB_NO_TB_TABLE_NAMES);
+
+  @BeforeAll
+  private static void setUp() {
+    DatabaseMetaDataTest.setUp(
+      Constants.ONE_DB_NO_TB_REGION,
+      Constants.ONE_DB_NO_TB_DATABASE_NAME,
+      Constants.ONE_DB_NO_TB_TABLE_NAMES);
+  }
+
+  @AfterAll
+  private static void cleanUp() {
+    DatabaseMetaDataTest.cleanUp(
+      Constants.ONE_DB_NO_TB_REGION,
+      Constants.ONE_DB_NO_TB_DATABASE_NAME,
+      Constants.ONE_DB_NO_TB_TABLE_NAMES);
+  }
+
+  @BeforeEach
+  private void init() throws SQLException {
+    dbTest.init();
+  }
+
+  @AfterEach
+  private void terminate() throws SQLException {
+    dbTest.terminate();
+  }
+
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getCatalogs(). Empty result set should be returned")
+  void testCatalogs() throws SQLException {
+    dbTest.testCatalogs();
+  }
+
+  /**
+   * Test getSchemas returns the database.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test retrieving the database.")
+  void testSchemas() throws SQLException {
+    dbTest.testSchemas();
+  }
+
+  /**
+   * Test getSchemas returns database "EmptyDb_1_2.34" when given matching patterns.
+   *
+   * @param schemaPattern the schema pattern to be tested
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"Empty_b!_1!_2.34' escape '!", "EmptyDb%", "%___2.34"})
+  @DisplayName("Test retrieving database name EmptyDb_1_2.34 with pattern.")
+  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
+    dbTest.testGetSchemasWithSchemaPattern(schemaPattern);
+  }
+
+  /**
+   * Test getTables returns no tables from empty database.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getTables returns no tables from empty database \"EmptyDb_1_2.34\"")
+  void testTables() throws SQLException {
+    dbTest.testTables();
+  }
+}

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataOneDBOneTBIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataOneDBOneTBIntegrationTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright <2020> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.timestream.integrationtest;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.timestream.jdbc.TimestreamDatabaseMetaData;
+
+import java.sql.SQLException;
+
+/**
+ * Integration tests for supported getters in {@link TimestreamDatabaseMetaData}
+ * Test case: One databases with one table
+ */
+class DatabaseMetaDataOneDBOneTBIntegrationTest {
+  private final DatabaseMetaDataTest dbTest = new DatabaseMetaDataTest(Constants.ONE_DB_ONE_TB_REGION,
+    Constants.ONE_DB_ONE_TB_DATABASE_NAME,
+    Constants.ONE_DB_ONE_TB_TABLE_NAME);
+
+  @BeforeAll
+  private static void setUp() {
+    DatabaseMetaDataTest.setUp(
+      Constants.ONE_DB_ONE_TB_REGION,
+      Constants.ONE_DB_ONE_TB_DATABASE_NAME,
+      Constants.ONE_DB_ONE_TB_TABLE_NAME);
+  }
+
+  @AfterAll
+  private static void cleanUp() {
+    DatabaseMetaDataTest.cleanUp(
+      Constants.ONE_DB_ONE_TB_REGION,
+      Constants.ONE_DB_ONE_TB_DATABASE_NAME,
+      Constants.ONE_DB_ONE_TB_TABLE_NAME);
+  }
+
+  @BeforeEach
+  private void init() throws SQLException {
+    dbTest.init();
+  }
+
+  @AfterEach
+  private void terminate() throws SQLException {
+    dbTest.terminate();
+  }
+
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getCatalogs(). Empty result set should be returned")
+  void testCatalogs() throws SQLException {
+    dbTest.testCatalogs();
+  }
+
+  /**
+   * Test getSchemas returns the database.
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test retrieving the database.")
+  void testSchemas() throws SQLException {
+    dbTest.testSchemas();
+  }
+
+  /**
+   * Test getSchemas returns database "JDBC_.IntegrationTestDB0088" when given matching patterns.
+   *
+   * @param schemaPattern the schema pattern to be tested
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"%0_88", "%!_.Integration%' escape '!", "JDBC%_ntegrationTestD_00_8"})
+  @DisplayName("Test retrieving database name JDBC_.IntegrationTestDB0088 with pattern.")
+  void testGetSchemasWithSchemaPattern(String schemaPattern) throws SQLException {
+    dbTest.testGetSchemasWithSchemaPattern(schemaPattern);
+  }
+
+  /**
+   * Test getTables returns the table from database "JDBC_.IntegrationTestDB0088".
+   *
+   * @throws SQLException the exception thrown
+   */
+  @Test
+  @DisplayName("Test getTables returns the table from database \"JDBC_.IntegrationTestDB0088\"")
+  void testTables() throws SQLException {
+    dbTest.testTables();
+  }
+
+  /**
+   * Test getTables returns tables from IntegrationTestTable0888 when given matching patterns.
+   *
+   * @param tablePattern  the table pattern to be tested
+   * @param schemaPattern the database pattern to be tested
+   * @param index         index of table name in Constants.ONE_DB_ONE_TB_TABLE_NAMES
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @CsvSource(value = {
+    "%Test%le08%, %0_88, 0",
+    "In_egratio_TestTable_888, %!_.Integration%' escape '!, 0",
+    "%8, JDBC%_ntegrationTestD_00_8, 0",
+  })
+  @DisplayName("Test retrieving IntegrationTestTable0888 from JDBC_.IntegrationTestDB0088.")
+  void testTablesWithPatternFromDBWithPattern(final String tablePattern, final String schemaPattern, final int index) throws SQLException {
+    dbTest.testTablesWithPatternFromDBWithPattern(tablePattern, schemaPattern, index);
+  }
+
+  /**
+   * Test getTables returns tables from IntegrationTestTable0888 when given matching patterns.
+   *
+   * @param tablePattern the table pattern to be tested
+   * @param index        index of table name in Constants.ONE_DB_ONE_TB_TABLE_NAMES
+   * @throws SQLException the exception thrown
+   */
+  @ParameterizedTest
+  @CsvSource(value = {
+    "%Test%le08%, 0",
+    "In_egratio_TestTable_888, 0",
+    "%8, 0",
+  })
+  @DisplayName("Test retrieving IntegrationTestTable0888 from JDBC_.IntegrationTestDB0088.")
+  void testTablesWithPattern(final String tablePattern, final int index) throws SQLException {
+    dbTest.testTablesWithPattern(tablePattern, index);
+  }
+}

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/DatabaseMetaDataTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright <2020> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.timestream.integrationtest;
+
+import org.junit.jupiter.api.Assertions;
+import software.amazon.timestream.jdbc.TimestreamDatabaseMetaData;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Integration tests for supported getters in {@link TimestreamDatabaseMetaData}
+ */
+class DatabaseMetaDataTest {
+  private DatabaseMetaData metaData;
+  private Connection connection;
+
+  private final String region;
+  private final String[] databases;
+  private final String[] tables;
+
+  DatabaseMetaDataTest(String r, String[] ds, String[] ts) {
+    region = r;
+    databases = ds;
+    tables = ts;
+  }
+
+  static void setUp(String r, String[] ds, String[] ts) {
+    TableManager.setRegion(r);
+    TableManager.createDatabases(ds);
+    TableManager.createTables(ts, ds);
+  }
+
+  static void cleanUp(String r, String[] ds, String[] ts) {
+    TableManager.setRegion(r);
+    TableManager.deleteTables(ts, ds);
+    TableManager.deleteDatabases(ds);
+  }
+
+  void init() throws SQLException {
+    final Properties p = new Properties();
+    p.setProperty("Region", region);
+    connection = DriverManager.getConnection(Constants.URL, p);
+    metaData = connection.getMetaData();
+  }
+
+  void terminate() throws SQLException {
+    connection.close();
+  }
+
+  /**
+   * Test getCatalogs returns empty ResultSet.
+   *
+   * @throws SQLException the exception thrown
+   */
+  void testCatalogs() throws SQLException {
+    final List<String> catalogsList = new ArrayList<>();
+    try (ResultSet catalogs = metaData.getCatalogs()) {
+      while (catalogs.next()) {
+        catalogsList.add(catalogs.getString("TABLE_CAT"));
+      }
+    }
+    Assertions.assertTrue(catalogsList.isEmpty());
+  }
+
+  /**
+   * Test getSchemas returns the database.
+   *
+   * @throws SQLException the exception thrown
+   */
+  public void testSchemas() throws SQLException {
+    final List<String> databaseList = Arrays.asList(databases);
+    final List<String> schemasList = new ArrayList<>();
+    try (ResultSet schemas = metaData.getSchemas()) {
+      while (schemas.next()) {
+        schemasList.add(schemas.getString("TABLE_SCHEM"));
+      }
+    }
+    Assertions.assertEquals(databaseList, schemasList);
+  }
+
+  /**
+   * Test getSchemas returns databases when given matching patterns.
+   *
+   * @param schemaPattern the schema pattern to be tested
+   * @throws SQLException the exception thrown
+   */
+  public void testGetSchemasWithSchemaPattern(final String schemaPattern) throws SQLException {
+    int schemasSize = 0;
+    try (ResultSet schemas = metaData.getSchemas(null, schemaPattern)) {
+      while (schemas.next()) {
+        final String schema = schemas.getString("TABLE_SCHEM");
+        final String match = Arrays
+            .stream(databases)
+            .filter(x -> x.equals(schema))
+            .findFirst()
+            .orElse(null);
+        Assertions.assertNotNull(match);
+        schemasSize++;
+      }
+      // Check the number of databases found match the actual number of databases
+      Assertions.assertEquals(databases.length, schemasSize);
+    }
+  }
+
+  /**
+   * Retrieve all tables from database
+   *
+   * @param schemaPattern database pattern
+   * @throws SQLException the exception thrown
+   */
+  private void getAllTables(String schemaPattern) throws SQLException {
+    final List<String> tableList = Arrays.asList(tables);
+    final List<String> returnTableList = new ArrayList<>();
+    try (ResultSet tables = metaData.getTables(null, schemaPattern, null, null)) {
+      while (tables.next()) {
+        returnTableList.add(tables.getString("TABLE_NAME"));
+      }
+    }
+    Assertions.assertEquals(tableList, returnTableList);
+  }
+
+  /**
+   * Test getTables returns the tables from the database.
+   *
+   * @throws SQLException the exception thrown
+   */
+  public void testTables() throws SQLException {
+    if (databases.length == 0) {
+      getAllTables(null);
+    }
+    for (String database : databases) {
+      getAllTables(database);
+    }
+  }
+
+  /**
+   * Test getTables returns tables from database when given matching patterns.
+   *
+   * @param tablePattern the table pattern to be tested
+   * @param index        index of table name in the database
+   * @throws SQLException the exception thrown
+   */
+  public void testTablesWithPattern(final String tablePattern, final int index) throws SQLException {
+    for (String database : databases) {
+      try (ResultSet tableResultSet = metaData.getTables(null, database, tablePattern, null)) {
+        Assertions.assertTrue(tableResultSet.next());
+        Assertions.assertEquals(tables[index], tableResultSet.getObject("TABLE_NAME"));
+      }
+    }
+  }
+
+  /**
+   * Test getTables returns tables from database when given matching patterns.
+   *
+   * @param tablePattern  the table pattern to be tested
+   * @param schemaPattern the database pattern to be tested
+   * @param index         index of table name in the database
+   * @throws SQLException the exception thrown
+   */
+  public void testTablesWithPatternFromDBWithPattern(final String tablePattern, final String schemaPattern, final int index) throws SQLException {
+    for (String database : databases) {
+      try (ResultSet tableResultSet = metaData.getTables(null, schemaPattern, tablePattern, null)) {
+        Assertions.assertTrue(tableResultSet.next());
+        Assertions.assertEquals(tables[index], tableResultSet.getObject("TABLE_NAME"));
+      }
+    }
+  }
+}

--- a/integrationtest/src/main/java/software/amazon/timestream/integrationtest/QueryExecutionIntegrationTest.java
+++ b/integrationtest/src/main/java/software/amazon/timestream/integrationtest/QueryExecutionIntegrationTest.java
@@ -40,13 +40,15 @@ class QueryExecutionIntegrationTest {
 
   @BeforeAll
   private static void setUp() {
-    TableManager.createTable();
+    TableManager.createDatabase(Constants.DATABASE_NAME);
+    TableManager.createTable(Constants.TABLE_NAME, Constants.DATABASE_NAME);
     TableManager.writeRecords();
   }
 
   @AfterAll
   private static void cleanUp() {
-    TableManager.deleteTable();
+    TableManager.deleteTable(Constants.TABLE_NAME, Constants.DATABASE_NAME);
+    TableManager.deleteDatabase(Constants.DATABASE_NAME);
   }
 
   @BeforeEach

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -70,7 +70,7 @@
 
         <!-- Dependency versions -->
         <awssdk.version>1.11.870</awssdk.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
         <jsoup.version>1.15.3</jsoup.version>
         <mockito.version>2.28.2</mockito.version>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -132,6 +132,33 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-file</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Source file to be copied -->
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/..</directory>
+                                    <includes>
+                                        <include>THIRD-PARTY-LICENSES.txt</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                            <!-- Destination directory where the file will be copied -->
+                            <outputDirectory>${project.basedir}/src/main/resources/META-INF</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
                 <version>1.0.0</version>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -69,10 +69,10 @@
         <argLine>-Duser.timezone=Europe/Paris</argLine>
 
         <!-- Dependency versions -->
-        <awssdk.version>1.11.870</awssdk.version>
+        <awssdk.version>1.12.512</awssdk.version>
         <guava.version>32.0.0-jre</guava.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
-        <jsoup.version>1.15.3</jsoup.version>
+        <jsoup.version>1.16.1</jsoup.version>
         <mockito.version>2.28.2</mockito.version>
         <slf4j.version>1.7.24</slf4j.version>
         <timestream.version>1.11.872</timestream.version>
@@ -225,7 +225,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.4</version>
+                <version>4.7.3.5</version>
                 <configuration>
                     <excludeFilterFile>src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
                     <xmlOutput>true</xmlOutput>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -78,6 +78,29 @@
         <timestream.version>1.11.872</timestream.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -333,19 +356,6 @@
                                 </filter>
                             </filters>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -17,7 +17,6 @@ package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
@@ -30,7 +29,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -41,12 +39,6 @@ public class TimestreamDataSource implements javax.sql.DataSource,
 
   private static final Logger LOGGER = Logger
     .getLogger("TimestreamDataSource");
-
-  static {
-    SLF4JBridgeHandler.removeHandlersForRootLogger();
-    SLF4JBridgeHandler.install();
-    LOGGER.setLevel(Level.FINE);
-  }
 
   @VisibleForTesting
   final ClientConfiguration clientConfiguration = new ClientConfiguration()

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -16,6 +16,7 @@
 package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.util.StringUtils;
 import com.google.common.annotations.VisibleForTesting;
 
 import javax.sql.ConnectionEvent;
@@ -712,13 +713,16 @@ public class TimestreamDataSource implements javax.sql.DataSource,
         throw new SQLException(error);
       }
 
-      if (this.region == null) {
+      if (StringUtils.isNullOrEmpty(this.region)) {
         final String error = Error.lookup(Error.MISSING_SERVICE_REGION);
         LOGGER.severe(error);
         throw new SQLException(error);
       }
 
       properties.put(TimestreamConnectionProperty.ENDPOINT.getConnectionProperty(), this.endpoint);
+    }
+
+    if (!StringUtils.isNullOrEmpty(this.region)) {
       properties.put(TimestreamConnectionProperty.REGION.getConnectionProperty(), this.region);
     }
 

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -17,18 +17,12 @@ package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
 import com.google.common.base.Strings;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
-import java.nio.charset.StandardCharsets;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -45,14 +39,6 @@ public class TimestreamDriver implements java.sql.Driver {
     static final String APPLICATION_NAME;
 
     static {
-        // We want to use SLF4J as the logging framework, so install the bridge for it.
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-
-        // Enable only >= FINE logs in the JUL Logger since we want to control things via SLF4J. JUL Logger will filter out
-        // messages before it gets to SLF4J if it set to a restrictive level.
-        LOGGER.setLevel(Level.FINE);
-
         APPLICATION_NAME = getApplicationName();
         APP_NAME_SUFFIX = " [" + APPLICATION_NAME + "]";
         LOGGER.finer("Name of the application using the driver: " + APP_NAME_SUFFIX);

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamSchemasResultSet.java
@@ -99,7 +99,7 @@ public class TimestreamSchemasResultSet extends TimestreamBaseResultSet {
       final String query = "SHOW DATABASES" +
               (Strings.isNullOrEmpty(schemaPattern) ? "" : " LIKE '" + schemaPattern + "'");
       try (ResultSet rs = statement.executeQuery(query)) {
-        while (rs != null && rs.next()) {
+        while (rs.next()) {
           databases.add(new Row().withData(
                   new Datum().withScalarValue(rs.getString(1)),
                   NULL_DATUM

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -18,6 +18,85 @@
     <Class name="software.amazon.timestream.jdbc.TimestreamTablesResultSet"/>
     <Method name="populateCurrentRows"/>
   </Match>
+
+  <!--
+    The errors:
+    Returning a reference to a mutable object value stored in one of the object's fields exposes the internal representation of the object.
+    If instances are accessed by untrusted code, and unchecked changes to the mutable object would compromise security or other important properties, you will need to do something different.
+    Returning a new copy of the object is better approach in many situations.
+
+    The code should allow users to be responsible for changing the state of the objects
+    -->
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getWarnings"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getResultSet"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="executeQuery"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamPooledConnection"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDriver"/>
+    <Method name="getParentLogger"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDatabaseMetaData"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDataSource"/>
+    <Method name="getParentLogger"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getWarnings"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getTypeMap"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getMetaData"/>
+  </Match>
+
+  <!--
+  The errors:
+  This code stores a reference to an externally mutable object into the internal representation of the object.
+  If instances are accessed by untrusted code, and unchecked changes to the mutable object would compromise security or other important properties,
+  you will need to do something different. Storing a copy of the object is better approach in many situations.
+
+  The code should allow to set external connection to the internal representation
+  -->
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDatabaseMetaData"/>
+    <Method name="&lt;init&gt;"/>
+  </Match>
+
   <Match>
     <!--The proper solution to this issue would be using Prepared Statement to construct
     a pre-compiled SQL query, and currently the driver does not support Prepared Statement,

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDataSourceTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDataSourceTest.java
@@ -105,6 +105,24 @@ class TimestreamDataSourceTest {
   }
 
   @Test
+  void testDataSourceWithEndpointDiscoveryAndRegion() throws SQLException {
+    final ArgumentCaptor<Properties> propertiesArgumentCaptor = ArgumentCaptor.forClass(Properties.class);
+    final MockTimestreamDataSource mockTimestreamDataSource = new MockTimestreamDataSource(
+        mockTimestreamConnection);
+
+    final Properties expected = new Properties();
+    expected.put(TimestreamConnectionProperty.REGION.getConnectionProperty(), "east");
+
+    mockTimestreamDataSource.setRegion("east");
+    mockTimestreamDataSource.getConnection();
+    Mockito.verify(mockTimestreamConnection).setClientInfo(propertiesArgumentCaptor.capture());
+
+    final Properties constructedConnectionProperties = propertiesArgumentCaptor.getValue();
+    Assertions.assertNotNull(constructedConnectionProperties);
+    Assertions.assertEquals(expected, constructedConnectionProperties);
+  }
+
+  @Test
   void testDataSourceWithEmptyEndpoint() {
     final MockTimestreamDataSource mockTimestreamDataSource = new MockTimestreamDataSource(
       mockTimestreamConnection);

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -31,8 +31,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -121,7 +121,7 @@ class TimestreamDatabaseMetaDataTest {
   @ParameterizedTest
   @ValueSource(strings = {"invalidDB"})
   void testGetSchemasWithInvalidSchemaPattern(String schemaPattern) throws SQLException {
-    initializeWithTwoResults();
+    initializeWithResult();
     try (ResultSet resultSet = dbMetaData
             .getSchemas(null, schemaPattern)) {
       testGetSchemasResult(resultSet, 0);
@@ -394,6 +394,7 @@ class TimestreamDatabaseMetaDataTest {
     Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE 'testDB'")).thenReturn(dbResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE '%testDB%'")).thenReturn(dbResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE 'emptyDB'")).thenReturn(emptydbResultSet);
+    Mockito.when(mockStatement.executeQuery("SHOW DATABASES LIKE 'invalidDB'")).thenReturn(emptyResultSet);
 
     final ResultSet singleTableResultSet = Mockito.mock(ResultSet.class);
     Mockito.when(singleTableResultSet.next()).thenReturn(true).thenReturn(false);
@@ -412,7 +413,7 @@ class TimestreamDatabaseMetaDataTest {
     Mockito.when(mockStatement.executeQuery("SHOW TABLES FROM \"testDB\" LIKE '%Ta_le'"))
       .thenReturn(singleTableResultSet);
     Mockito.when(mockStatement.executeQuery("SHOW TABLES FROM \"emptyDB\""))
-            .thenReturn(emptyResultSet);
+      .thenReturn(emptyResultSet);
 
     final ResultSet columnsResultSet = Mockito.mock(ResultSet.class);
     Mockito.when(columnsResultSet.next()).thenReturn(true).thenReturn(true).thenReturn(false);
@@ -420,7 +421,7 @@ class TimestreamDatabaseMetaDataTest {
     Mockito.when(mockStatement.executeQuery("DESCRIBE \"testDB\".\"testTable\""))
       .thenReturn(columnsResultSet);
     Mockito.when(mockStatement.executeQuery("DESCRIBE \"testDB\".\"secondTable\""))
-            .thenReturn(columnsResultSet);
+      .thenReturn(columnsResultSet);
   }
 
   /**
@@ -469,7 +470,7 @@ class TimestreamDatabaseMetaDataTest {
     while (resultSet.next()) {
       int match = 0;
       for (int i = 1; i <= resultSet.getMetaData().getColumnCount(); ++i) {
-        if (strings.get(numRows)[i-1] == resultSet.getString(i)) {
+        if (Objects.equals(strings.get(numRows)[i - 1], resultSet.getString(i))) {
           match++;
         }
       }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <awssdk.version>1.11.870</awssdk.version>
-    <guava.version>29.0-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <jsoup.version>1.15.3</jsoup.version>
     <maven.install.version>3.0.0-M1</maven.install.version>


### PR DESCRIPTION
## Summary
Add Support for region override with endpoint discovery.

## Description
Users should be able to override the region for a connection with the URL and endpoint discovery. Prior to fix when using endpoint discovery the region would not be set.

## Related Issue
Issue: [34](https://github.com/awslabs/amazon-timestream-driver-jdbc/issues/34)

## Tests performed/created
Following Tests has been executed manually:
-  Tested in demo application thanks to Dima ✅ 
```
    TimestreamDataSource timestreamDataSource = new TimestreamDataSource();
    timestreamDataSource.setRegion("us-west-2");
    
    try (Connection connection = timestreamDataSource.getConnection("AccessKey", "AccessSecret")) {
        connection.getMetaData();
        Statement statement = connection.createStatement();
        ResultSet resultSet = statement.executeQuery("SELECT * FROM \"demoDB\".\"demoTable\" ORDER BY time DESC LIMIT 10 ");
        statement.close();
        while (resultSet.next()) {
            System.out.println(resultSet);
        }
    }
```

## Additional Reviewers
@alexeytemnikov
