### PR TITLE
Change logic for metadata info (use constant value and version)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Pdeploy
     - name: Upload JARs
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Pdeploy
     - name: Upload JARs to release
       uses: AButler/upload-release-assets@v2.0
       with:

--- a/README.md
+++ b/README.md
@@ -454,6 +454,23 @@ To use the JAR with no dependencies in a Java application, the following require
 ### Building and using the Javadoc JAR to extract the Javadoc HTML files (amazon-timestream-jdbc-\<version\>-javadoc.jar)
 Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract the Javadoc HTML files, use the following command: `jar -xvf amazon-timestream-jdbc-1.0.0-javadoc.jar`
 
+### Debug with BI tools
+#### DBeaver
+To enable debug logs, the application should be run with `-Ddbeaver.trace.enabled=true` flag
+
+#### DbVisualizer
+To enable debug mode, the following steps should be done:
+1. Open `Tools -> Debug Window`
+2. Open the `Debug Log` tab
+3. Enable the `Debug DbVisualizer` checkbox
+
+#### Tableau Desktop
+To enable debug mode need to run Tableau Desktop with -DLogLevel=debug flag
+More details on the official [documentation](https://kb.tableau.com/articles/howto/how-to-create-tableau-desktop-debug-logs)
+
+#### Java Application
+Need to change log level to Debug/FINE. See official documentation how to change log level.
+
 ### Known Issues
 1. Timestream does not support fully qualified table names.
 2. Timestream does not support the queries that contain ":" in the column aliases. Tools like Tableau may not work as expected.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Upon completion, the page will be redirected back to the `Identity providers` pa
 
 ### Building the fully shaded JAR With All Dependencies Shaded Except SLF4J (amazon-timestream-jdbc-\<version\>-jar-with-all-dependencies.jar)
 To build a fully shaded JAR, comment out the following two lines in the pom file in the [/jdbc/pom.xml](/jdbc/pom.xml) then run `mvn install`.
+#### To build the signed jar the following maven profile should be used: `mvn clean install -Ddeploy`.
 
 ```xml
 <scope>system</scope>
@@ -453,6 +454,14 @@ To use the JAR with no dependencies in a Java application, the following require
 
 ### Building and using the Javadoc JAR to extract the Javadoc HTML files (amazon-timestream-jdbc-\<version\>-javadoc.jar)
 Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract the Javadoc HTML files, use the following command: `jar -xvf amazon-timestream-jdbc-1.0.0-javadoc.jar`
+
+### GPG Installation
+For building signed jar before executing: `mvn clean install -Pdeploy` the following setup should be done
+1. Download and install GPG https://gnupg.org/download/
+2. Generate new key:
+   For GPG version 2.1.17 or greater: `gpg --full-generate-key`
+   For GPG version lower than 2.1.17: `gpg --default-new-key-algo rsa4096 --gen-key`
+3. Export GPG TTY: `export GPG_TTY=$(tty)`
 
 ### Known Issues
 1. Timestream does not support fully qualified table names.

--- a/README.md
+++ b/README.md
@@ -456,7 +456,22 @@ Javadoc JAR builds with `mvn install` alongside the other JAR files. To extract 
 
 ### Debug with BI tools
 #### DBeaver
-To enable debug logs, the application should be run with `-Ddbeaver.trace.enabled=true` flag
+1. Search `dbeaver.ini` file - It should be in the home DBeaver directory
+2. Open `dbeaver.ini` file and add line `-Ddbeaver.jdbc.trace=true` to the end of the file 
+3. Restart DBeaver Application
+4. Add driver and Connect to your timestream database.
+5. In DBeaver `Workspace` go to `.metadata` folder
+6. File `jdbc-api-trace.log` contains all JDBC API invocations and all queries with results.
+
+##### The log location Mac example
+/Library/DBeaverData/workspace6/.metadata/dbeaver-debug.log
+
+#### Log example
+2023-07-24 14:53:57.819 - Initializing the client.
+2023-07-24 14:53:57.819 - Creating an AWSStaticCredentialsProvider.
+2023-07-24 14:53:58.375 - Execution context opened (Timestream; Metadata; 1)
+2023-07-24 14:53:58.377 - Initializing the client.
+2023-07-24 14:53:58.377 - Creating an AWSStaticCredentialsProvider.
 
 #### DbVisualizer
 To enable debug mode, the following steps should be done:
@@ -464,12 +479,46 @@ To enable debug mode, the following steps should be done:
 2. Open the `Debug Log` tab
 3. Enable the `Debug DbVisualizer` checkbox
 
+##### The log file location
+`$HOME/.dbvis/sqllogs folder with the .dson extension`
+
 #### Tableau Desktop
 To enable debug mode need to run Tableau Desktop with -DLogLevel=debug flag
 More details on the official [documentation](https://kb.tableau.com/articles/howto/how-to-create-tableau-desktop-debug-logs)
 
 #### Java Application
-Need to change log level to Debug/FINE. See official documentation how to change log level.
+Need to change the log level to `DEBUG` or `FINE`.
+
+#### For Spring based application 
+The log level can be modified by changing application.properties
+
+`logging.level.root=DEBUG`
+`logging.level.software.amazon.timestream.jdbc=FINE`
+
+#### By VM arguments
+1. Create file `logging.properties`
+2. Add line `software.amazon.timestream.jdbc=FINE` to the `logging.properties` file
+3. Run application with arguments `-Djava.util.logging.config.file="logging.properties"`
+
+#### Programmatically in the code
+`public static void setLogLevel(Level level) {
+Logger rootLogger = LogManager.getLogManager().getLogger("");
+   Handler[] handlers = rootLogger.getHandlers();
+   rootLogger.setLevel(level);
+   for (Handler handler : handlers) {
+      if(handler instanceof FileHandler) {
+         handler.setLevel(newLvl);
+      }
+   }`
+}`
+
+#### Logs example
+
+21:23:51.255 [main] INFO software.amazon.timestream.jdbc.TimestreamConnection - Initializing the client.
+21:23:51.256 [main] INFO software.amazon.timestream.jdbc.TimestreamConnection - Creating an AWSStaticCredentialsProvider.
+Jul. 25, 2023 9:23:51 P.M. com.amazonaws.internal.DefaultServiceEndpointBuilder getServiceEndpoint
+INFO: {query.timestream, us-west-2} was not found in region metadata, trying to construct an endpoint using the standard pattern for this region: region
+21:23:53.191 [main] INFO software.amazon.timestream.jdbc.TimestreamStatement - Query ID: SOME_ID
 
 ### Known Issues
 1. Timestream does not support fully qualified table names.

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -78,6 +78,29 @@
         <timestream.version>1.11.872</timestream.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -306,19 +329,6 @@
                                 </filter>
                             </filters>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -69,10 +69,10 @@
         <argLine>-Duser.timezone=Europe/Paris</argLine>
 
         <!-- Dependency versions -->
-        <awssdk.version>1.11.870</awssdk.version>
+        <awssdk.version>1.12.512</awssdk.version>
         <guava.version>29.0-jre</guava.version>
         <junit.jupiter.version>5.6.2</junit.jupiter.version>
-        <jsoup.version>1.15.3</jsoup.version>
+        <jsoup.version>1.16.1</jsoup.version>
         <mockito.version>2.28.2</mockito.version>
         <slf4j.version>1.7.24</slf4j.version>
         <timestream.version>1.11.872</timestream.version>
@@ -198,7 +198,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.4</version>
+                <version>4.7.3.5</version>
                 <configuration>
                     <excludeFilterFile>src/main/spotbugs/spotbugs-exclude.xml</excludeFilterFile>
                     <xmlOutput>true</xmlOutput>

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -17,7 +17,6 @@ package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
@@ -25,12 +24,7 @@ import javax.sql.PooledConnection;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.logging.Level;
+import java.util.*;
 import java.util.logging.Logger;
 
 /**
@@ -41,12 +35,6 @@ public class TimestreamDataSource implements javax.sql.DataSource,
 
   private static final Logger LOGGER = Logger
     .getLogger("TimestreamDataSource");
-
-  static {
-    SLF4JBridgeHandler.removeHandlersForRootLogger();
-    SLF4JBridgeHandler.install();
-    LOGGER.setLevel(Level.FINE);
-  }
 
   @VisibleForTesting
   final ClientConfiguration clientConfiguration = new ClientConfiguration()

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -24,7 +24,11 @@ import javax.sql.PooledConnection;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.logging.Logger;
 
 /**

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDataSource.java
@@ -43,7 +43,7 @@ public class TimestreamDataSource implements javax.sql.DataSource,
   @VisibleForTesting
   final ClientConfiguration clientConfiguration = new ClientConfiguration()
     .withUserAgentSuffix(
-      Constants.UA_ID_PREFIX + TimestreamDriver.DRIVER_VERSION + TimestreamDriver.APP_NAME_SUFFIX);
+      Constants.UA_ID_PREFIX + TimestreamDriver.DRIVER_VERSION);
   @VisibleForTesting
   final Map<Properties, LinkedList<TimestreamConnection>> availablePools = new HashMap<>();
   private final Properties samlAuthenticationProperties = new Properties();

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -17,18 +17,12 @@ package software.amazon.timestream.jdbc;
 
 import com.amazonaws.ClientConfiguration;
 import com.google.common.base.Strings;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.management.ManagementFactory;
-import java.nio.charset.StandardCharsets;
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -45,14 +39,6 @@ public class TimestreamDriver implements java.sql.Driver {
     static final String APPLICATION_NAME;
 
     static {
-        // We want to use SLF4J as the logging framework, so install the bridge for it.
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-
-        // Enable only >= FINE logs in the JUL Logger since we want to control things via SLF4J. JUL Logger will filter out
-        // messages before it gets to SLF4J if it set to a restrictive level.
-        LOGGER.setLevel(Level.FINE);
-
         APPLICATION_NAME = getApplicationName();
         APP_NAME_SUFFIX = " [" + APPLICATION_NAME + "]";
         LOGGER.finer("Name of the application using the driver: " + APP_NAME_SUFFIX);

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDriver.java
@@ -35,13 +35,11 @@ public class TimestreamDriver implements java.sql.Driver {
     static final int DRIVER_MAJOR_VERSION;
     static final int DRIVER_MINOR_VERSION;
     static final String DRIVER_VERSION;
-    static final String APP_NAME_SUFFIX;
     static final String APPLICATION_NAME;
 
     static {
         APPLICATION_NAME = getApplicationName();
-        APP_NAME_SUFFIX = " [" + APPLICATION_NAME + "]";
-        LOGGER.finer("Name of the application using the driver: " + APP_NAME_SUFFIX);
+        LOGGER.finer("Name of the application using the driver: " + APPLICATION_NAME);
 
         // Load the driver version from the associated pom file.
         int majorVersion = 0;
@@ -147,7 +145,7 @@ public class TimestreamDriver implements java.sql.Driver {
      * @return The User Agent Suffix.
      */
     static String getUserAgentSuffix() {
-        return Constants.UA_ID_PREFIX + DRIVER_VERSION + APP_NAME_SUFFIX;
+        return Constants.UA_ID_PREFIX + DRIVER_VERSION;
     }
 
     @Override
@@ -161,10 +159,7 @@ public class TimestreamDriver implements java.sql.Driver {
      * @return the name of the currently running application.
      */
     private static String getApplicationName() {
-        // Currently not supported.
-        // Need to implement logic to get the process ID of the current process, then check the set of running processes and pick out
-        // the one that matches the current process. From there we can grab the name of what is running the process.
-        return "Unknown";
+        return "ts-jdbc." + TimestreamDriver.DRIVER_VERSION;
     }
 
     /**

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -18,14 +18,85 @@
     <Class name="software.amazon.timestream.jdbc.TimestreamTablesResultSet"/>
     <Method name="populateCurrentRows"/>
   </Match>
+
+  <!--
+    The errors:
+    Returning a reference to a mutable object value stored in one of the object's fields exposes the internal representation of the object.
+    If instances are accessed by untrusted code, and unchecked changes to the mutable object would compromise security or other important properties, you will need to do something different.
+    Returning a new copy of the object is better approach in many situations.
+
+    The code should allow users to be responsible for changing the state of the objects
+    -->
   <Match>
     <Bug pattern="EI_EXPOSE_REP"/>
-    <Package name="software.amazon.timestream.jdbc"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getWarnings"/>
   </Match>
   <Match>
-    <Bug pattern="EI_EXPOSE_REP2"/>
-    <Package name="software.amazon.timestream.jdbc"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getResultSet"/>
   </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamStatement"/>
+    <Method name="executeQuery"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamPooledConnection"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDriver"/>
+    <Method name="getParentLogger"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDatabaseMetaData"/>
+    <Method name="getConnection"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDataSource"/>
+    <Method name="getParentLogger"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getWarnings"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getTypeMap"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamConnection"/>
+    <Method name="getMetaData"/>
+  </Match>
+
+  <!--
+  The errors:
+  This code stores a reference to an externally mutable object into the internal representation of the object.
+  If instances are accessed by untrusted code, and unchecked changes to the mutable object would compromise security or other important properties,
+  you will need to do something different. Storing a copy of the object is better approach in many situations.
+
+  The code should allow to set external connection to the internal representation
+  -->
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Class name="software.amazon.timestream.jdbc.TimestreamDatabaseMetaData"/>
+    <Method name="&lt;init&gt;"/>
+  </Match>
+
   <Match>
     <!--The proper solution to this issue would be using Prepared Statement to construct
     a pre-compiled SQL query, and currently the driver does not support Prepared Statement,

--- a/jdbc/src/main/spotbugs/spotbugs-exclude.xml
+++ b/jdbc/src/main/spotbugs/spotbugs-exclude.xml
@@ -19,6 +19,14 @@
     <Method name="populateCurrentRows"/>
   </Match>
   <Match>
+    <Bug pattern="EI_EXPOSE_REP"/>
+    <Package name="software.amazon.timestream.jdbc"/>
+  </Match>
+  <Match>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+    <Package name="software.amazon.timestream.jdbc"/>
+  </Match>
+  <Match>
     <!--The proper solution to this issue would be using Prepared Statement to construct
     a pre-compiled SQL query, and currently the driver does not support Prepared Statement,
     so the exclude is added.

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamConnectionTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamConnectionTest.java
@@ -231,7 +231,7 @@ class TimestreamConnectionTest {
   void testUserAgentIdentifierSuffix() {
     final String actualSuffix = connection.clientConfiguration.getUserAgentSuffix();
     final String expectedSuffix =
-        Constants.UA_ID_PREFIX + TimestreamDriver.DRIVER_VERSION + TimestreamDriver.APP_NAME_SUFFIX;
+        Constants.UA_ID_PREFIX + TimestreamDriver.DRIVER_VERSION;
     Assertions.assertEquals(expectedSuffix, actualSuffix);
   }
 

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDataSourceTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDataSourceTest.java
@@ -295,7 +295,7 @@ class TimestreamDataSourceTest {
   void testUserAgentIdentifierSuffix() {
     final String actualSuffix = timestreamDataSource.clientConfiguration.getUserAgentSuffix();
     final String expectedSuffix =
-      Constants.UA_ID_PREFIX + TimestreamDriver.DRIVER_VERSION + TimestreamDriver.APP_NAME_SUFFIX;
+      Constants.UA_ID_PREFIX + TimestreamDriver.DRIVER_VERSION;
     Assertions.assertEquals(expectedSuffix, actualSuffix);
   }
 


### PR DESCRIPTION
## Summary
JDBC - Application Name Reporting

## Description
Use static application name for metrics (userAgent information). 
The name is added to the agent suffix in the following format:
`Constants.UA_ID_PREFIX + TimestreamDriver.DRIVER_VERSION)`
Where UA_ID_PREFIX is "ts-jdbc." and the version contains major and minor information

## Related Issue
N/A

## Tests performed/created
N/A


## Additional Reviewers
@alexeytemnikov
