### PR TITLE
Update dependency for JDBC application

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -14,7 +14,6 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>software.amazon.timestream</groupId>
     <artifactId>amazon-timestream-jdbc</artifactId>
     <version>2.0.0</version>
@@ -29,6 +28,12 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
+
+    <parent>
+        <groupId>software.amazon.timestream</groupId>
+        <artifactId>timestream</artifactId>
+        <version>2.0.0</version>
+    </parent>
 
     <scm>
         <connection>scm:git:git://github.com:awslabs/amazon-timestream-driver-jdbc.git</connection>
@@ -54,11 +59,6 @@
     </distributionManagement>
 
     <properties>
-        <!-- Optionally specify a compiler here, we chose Java 8 -->
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
         <!-- Version properties are written out to be picked up by the driver. -->
         <driver.major.version>2</driver.major.version>
         <driver.minor.version>0</driver.minor.version>
@@ -67,15 +67,6 @@
 
         <!-- Set the timezone information for unit tests. -->
         <argLine>-Duser.timezone=Europe/Paris</argLine>
-
-        <!-- Dependency versions -->
-        <awssdk.version>1.12.512</awssdk.version>
-        <guava.version>32.0.0-jre</guava.version>
-        <junit.jupiter.version>5.6.2</junit.jupiter.version>
-        <jsoup.version>1.16.1</jsoup.version>
-        <mockito.version>2.28.2</mockito.version>
-        <slf4j.version>1.7.24</slf4j.version>
-        <timestream.version>1.11.872</timestream.version>
     </properties>
 
     <profiles>
@@ -105,49 +96,40 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
-            <version>${awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-timestreamquery</artifactId>
-            <version>${timestream.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>${jsoup.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamColumnsResultSet.java
@@ -65,9 +65,9 @@ public class TimestreamColumnsResultSet extends TimestreamBaseResultSet {
     TimestreamDataType.createColumnInfo(TimestreamDataType.VARCHAR, "IS_GENERATEDCOLUMN"));
 
   /* Index of table schema value in the resultSet returned from getTables() */
-  private final int TABLE_SCHEM_INDX = 2;
+  private static final int TABLE_SCHEM_INDX = 2;
   /* Index of table name value in the resultSet returned from getTables() */
-  private final int TABLE_NAME_INDX = 3;
+  private static final int TABLE_NAME_INDX = 3;
 
   private final TimestreamStatement statement;
   private ResultSet result;

--- a/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
+++ b/jdbc/src/main/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaData.java
@@ -171,7 +171,7 @@ public class TimestreamDatabaseMetaData implements java.sql.DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getCatalogs(){
+  public ResultSet getCatalogs() {
     LOGGER.debug("Catalogs are not supported. Returning an empty result set.");
     return new TimestreamDatabasesResultSet();
   }

--- a/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
+++ b/jdbc/src/test/java/software/amazon/timestream/jdbc/TimestreamDatabaseMetaDataTest.java
@@ -57,6 +57,8 @@ class TimestreamDatabaseMetaDataTest {
 
   /**
    * Checks that an empty result set is returned for getCatalogs
+   *
+   * @throws SQLException The method can throw an SQLException
    */
   @Test
   void testGetCatalogsWithResult() throws SQLException {
@@ -69,6 +71,8 @@ class TimestreamDatabaseMetaDataTest {
 
   /**
    * Checks that all result sets are returned for getSchemas with no parameters
+   *
+   * @throws SQLException The method can throw an SQLException
    */
   @Test
   void testGetSchemasWithResult() throws SQLException {
@@ -82,6 +86,8 @@ class TimestreamDatabaseMetaDataTest {
 
   /**
    * Checks that all result sets are returned for getSchemas with null parameters
+   *
+   * @throws SQLException The method can throw an SQLException
    */
   @Test
   void testGetSchemasNullParamWithResult() throws SQLException {
@@ -97,6 +103,8 @@ class TimestreamDatabaseMetaDataTest {
    * Checks that all result sets are returned for getSchemas with schemaPattern
    * @param schemaPattern Schema pattern to be tested
    * @param expectedValue Expected resultset number
+   *
+   * @throws SQLException The method can throw an SQLException
    */
   @ParameterizedTest
   @CsvSource(value = {
@@ -117,6 +125,8 @@ class TimestreamDatabaseMetaDataTest {
   /**
    * Checks that nothing could be returned for invalid schema
    * @param schemaPattern Schema pattern to be tested
+   *
+   * @throws SQLException The method can throw an SQLException
    */
   @ParameterizedTest
   @ValueSource(strings = {"invalidDB"})
@@ -130,17 +140,19 @@ class TimestreamDatabaseMetaDataTest {
 
   /**
    * Checks that exception "access denied" could be thrown
+   *
+   * @throws SQLException The method can throw an SQLException
    */
   @Test
   void testGetSchemasWithResultException() throws SQLException {
     initializeWithResultException();
 
     try {
-      ResultSet resultSet = dbMetaData.getSchemas();
+      dbMetaData.getSchemas();
       Assertions.fail("unexpected success");
     } catch (AmazonTimestreamQueryException ae) {
       Assertions.assertEquals(ae.getErrorMessage(), "access denied");
-    } catch(Exception e) {
+    } catch (Exception e) {
       Assertions.fail("unexpected exception " + e.getMessage());
     }
   }
@@ -242,6 +254,8 @@ class TimestreamDatabaseMetaDataTest {
 
   /**
    * Checks that empty result set is returned for empty database
+   *
+   * @throws SQLException The method can throw an SQLException
    */
   @Test
   void testGetTablesWithEmptyDatabase() throws SQLException {

--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,14 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <awssdk.version>1.11.870</awssdk.version>
-    <guava.version>32.0.0-jre</guava.version>
+    <awssdk.version>1.12.530</awssdk.version>
+    <guava.version>32.1.2-jre</guava.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
-    <jsoup.version>1.15.3</jsoup.version>
+    <jsoup.version>1.16.1</jsoup.version>
     <maven.install.version>3.0.0-M1</maven.install.version>
     <mockito.version>2.28.2</mockito.version>
     <slf4j.version>1.7.24</slf4j.version>
-    <timestream.version>1.11.872</timestream.version>
+    <timestream.version>1.12.530</timestream.version>
     <timestream.jdbc.version>2.0.0</timestream.jdbc.version>
   </properties>
 
@@ -89,6 +89,18 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
         <version>${junit.jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>software.amazon.timestream</groupId>


### PR DESCRIPTION
## Summary
The build uses old dependencies that have vulnerability issues.
The JDBC don't have a parent pom and use own dependency list

## Description
The dependency has been updated for aws core and jsoup 
The shecksyles have been fixed

## Related Issue
AT-1482

## Tests performed/created
### Unit tests: 
All existing Unit tests passed

### Manual verification:
1. Change java to 1.8: `export JAVA_HOME=`/usr/libexec/java_home -v 1.8``
2. Build the project with the command `mvn clean install`
3. Verify that all tests passed and build successful

-------

1. Change java to 1.8: `export JAVA_HOME=`/usr/libexec/java_home -v 11``
2. Build the project with the command `mvn clean install`
3. Verify that all tests passed and build successful

-------

1. Change java to 1.8: `export JAVA_HOME=`/usr/libexec/java_home -v 16``
2. Build the project with the command `mvn clean install`
3. Verify that all tests passed and build successful


## Additional Reviewers
@alexey-temnikov 